### PR TITLE
Clean up RTE interface.

### DIFF
--- a/PRE_RELEASE.md
+++ b/PRE_RELEASE.md
@@ -1,3 +1,5 @@
+> Manual pre-release checklist. Automated quality control (formatting, linting, tests, coverage) is enforced by CI on all PRs and merges.
+
 1. Bump version.
 2. Run formatters:
     ```bash 

--- a/_demos/general/demo_DELO.py
+++ b/_demos/general/demo_DELO.py
@@ -1,27 +1,28 @@
-import logging
-
 import numpy as np
 from numpy import real
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.common_api.constant_property_slab import ConstantPropertySlabAtmosphere
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.object.stokes import Stokes
-from solrat.atom_model.shared.utility.functions import get_planck_BP, lambda_A_to_frequency_hz
-from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesNorm, StokesPlotter
+from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range, get_planck_BP
+from solrat.atom_model.shared.utility.log_setup import setup_logging
+from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesPlotter
 
 
 def main():
     """
-    This demo shows how the DELO solver works against the different more primitive finite difference methods.
+    This demo shows how the DELO solver works against the different more primitive finite difference method.
     """
-    logging_config.init(logging.INFO)
+    setup_logging()
 
     model = PreconfiguredModels.multi_term_atom_HeID3()
-    reference_lambda = model.config.reference_lambda_A
-    lambda_A = np.arange(reference_lambda - 1, reference_lambda + 1, 1e-3)
-    nu = lambda_A_to_frequency_hz(lambda_A)
+    reference_lambda_A_air = model.config.reference_lambda_A_air
+    nu = get_frequencies_from_air_wavelength_range(
+        lower_wavelength_A=reference_lambda_A_air - 1,
+        upper_wavelength_A=reference_lambda_A_air + 1,
+        step_A=1e-3,
+    )
 
     angles = Angles(
         chi=30 * np.pi / 180,
@@ -31,7 +32,9 @@ def main():
         theta_B=20 * np.pi / 180,
     )
 
-    plotter = StokesPlotter("Comparison of DELO and Finite Difference (Euler) integration", vacuum_to_air=True)
+    plotter = StokesPlotter(
+        "Comparison of DELO and Finite Difference integration", reference_lambda_A_air=reference_lambda_A_air
+    )
 
     atmosphere_parameters = model.AtmosphereParameters(
         model_config=model.config,
@@ -57,10 +60,9 @@ def main():
     )
 
     plotter.add_stokes(
-        lambda_A=lambda_A,
-        lambda_ref_A=reference_lambda,
+        nu=nu,
         stokes=atmosphere.forward(initial_stokes=initial_stokes),
-        norm=StokesNorm.BY_REFERENCE,
+        norm=StokesPlotter.Norm.BY_REFERENCE,
         stokes_reference=initial_stokes,
         label="DELO",
     )
@@ -80,7 +82,7 @@ def main():
     K_tau_line[:, 1, 1] += 1 / eta_LC
     K_tau_line[:, 2, 2] += 1 / eta_LC
     K_tau_line[:, 3, 3] += 1 / eta_LC
-    epsilon_tau_line[:, 0] += get_planck_BP(nu_sm1=nu, T_K=atmosphere_parameters.temperature_K) / eta_LC
+    epsilon_tau_line[:, 0] += get_planck_BP(nu_sm1=nu, temperature_K=atmosphere_parameters.temperature_K) / eta_LC
 
     # Rename to be explicit
     K_tau = K_tau_line
@@ -106,8 +108,7 @@ def main():
 
         if i % 2 == 1:
             plotter.add_stokes(
-                lambda_A=lambda_A,
-                lambda_ref_A=reference_lambda,
+                nu=nu,
                 stokes=Stokes(
                     nu=nu,
                     I=real(stokes[:, 0, 0]),
@@ -115,7 +116,7 @@ def main():
                     U=real(stokes[:, 2, 0]),
                     V=real(stokes[:, 3, 0]),
                 ),
-                norm=StokesNorm.BY_REFERENCE,
+                norm=StokesPlotter.Norm.BY_REFERENCE,
                 stokes_reference=initial_stokes,
                 label=f"FD (step #{i+1}/{n_steps})",
                 linewidth=0.5,

--- a/_demos/general/demo_DELO.py
+++ b/_demos/general/demo_DELO.py
@@ -9,7 +9,7 @@ from solrat.atom_model.shared.common_api.constant_property_slab import ConstantP
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.object.stokes import Stokes
 from solrat.atom_model.shared.utility.functions import get_planck_BP, lambda_A_to_frequency_hz
-from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesPlotter
+from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesNorm, StokesPlotter
 
 
 def main():
@@ -31,7 +31,7 @@ def main():
         theta_B=20 * np.pi / 180,
     )
 
-    plotter = StokesPlotter("Comparison of DELO and Finite Difference (Euler) integration")
+    plotter = StokesPlotter("Comparison of DELO and Finite Difference (Euler) integration", vacuum_to_air=True)
 
     atmosphere_parameters = model.AtmosphereParameters(
         model_config=model.config,
@@ -58,8 +58,9 @@ def main():
 
     plotter.add_stokes(
         lambda_A=lambda_A,
-        reference_lambda_A=reference_lambda,
+        lambda_ref_A=reference_lambda,
         stokes=atmosphere.forward(initial_stokes=initial_stokes),
+        norm=StokesNorm.BY_REFERENCE,
         stokes_reference=initial_stokes,
         label="DELO",
     )
@@ -106,7 +107,7 @@ def main():
         if i % 2 == 1:
             plotter.add_stokes(
                 lambda_A=lambda_A,
-                reference_lambda_A=reference_lambda,
+                lambda_ref_A=reference_lambda,
                 stokes=Stokes(
                     nu=nu,
                     I=real(stokes[:, 0, 0]),
@@ -114,6 +115,7 @@ def main():
                     U=real(stokes[:, 2, 0]),
                     V=real(stokes[:, 3, 0]),
                 ),
+                norm=StokesNorm.BY_REFERENCE,
                 stokes_reference=initial_stokes,
                 label=f"FD (step #{i+1}/{n_steps})",
                 linewidth=0.5,

--- a/_demos/general/demo_NLTE_n_w_parametrized.py
+++ b/_demos/general/demo_NLTE_n_w_parametrized.py
@@ -13,7 +13,7 @@ def main():
     This recreates Fig. 4 in A. Asensio Ramos et al 2008 ApJ 683 542 https://iopscience.iop.org/article/10.1086/589433
     Here, we use the parametrized smooth version of the n(lambda) and w(lambda) function
     """
-    setup_logging(logging.INFO)
+    setup_logging()
     # Load the atomic data for He I D3
     config = get_He_I_D3_config()
 

--- a/_demos/general/demo_NLTE_n_w_parametrized.py
+++ b/_demos/general/demo_NLTE_n_w_parametrized.py
@@ -2,10 +2,10 @@ import logging
 
 import matplotlib.pyplot as plt
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.multi_term_atom_model.data.HeI import get_He_I_D3_config
 from solrat.atom_model.multi_term_atom_model.object.radiation_tensor import RadiationTensor
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 
 
 def main():
@@ -13,7 +13,7 @@ def main():
     This recreates Fig. 4 in A. Asensio Ramos et al 2008 ApJ 683 542 https://iopscience.iop.org/article/10.1086/589433
     Here, we use the parametrized smooth version of the n(lambda) and w(lambda) function
     """
-    logging_config.init(logging.INFO)
+    setup_logging(logging.INFO)
     # Load the atomic data for He I D3
     config = get_He_I_D3_config()
 
@@ -61,7 +61,7 @@ def main():
             [radiation_tensor.data[transition_id] for transition_id in transitions_to_plot],
             label=f"h_arcsec={h_arcsec}",
         )
-    radiation_tensor.fill_planck(T_K=5700)
+    radiation_tensor.fill_planck(temperature_K=5700)
     ax[2].scatter(x_axis, [0 for _ in transitions_to_plot], label="LTE")
 
     ax[2].set_xlabel(r"Transition in He I atom")

--- a/_demos/general/demo_paschen_back.py
+++ b/_demos/general/demo_paschen_back.py
@@ -2,10 +2,10 @@ import logging
 
 import matplotlib.pyplot as plt
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.multi_term_atom_model.object.level_registry import LevelRegistry
 from solrat.atom_model.multi_term_atom_model.utility.paschen_back import calculate_paschen_back
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 
 
 def main():
@@ -15,7 +15,7 @@ def main():
     and the complete Paschen-Back regime.
     """
 
-    logging_config.init(logging.INFO)
+    setup_logging(logging.INFO)
 
     level_registry = LevelRegistry()
     level_registry.register_level(

--- a/_demos/general/demo_paschen_back.py
+++ b/_demos/general/demo_paschen_back.py
@@ -1,5 +1,3 @@
-import logging
-
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -15,7 +13,7 @@ def main():
     and the complete Paschen-Back regime.
     """
 
-    setup_logging(logging.INFO)
+    setup_logging()
 
     level_registry = LevelRegistry()
     level_registry.register_level(

--- a/_demos/general/demo_paschen_back_FeI5434.py
+++ b/_demos/general/demo_paschen_back_FeI5434.py
@@ -2,13 +2,13 @@ import logging
 
 import matplotlib.pyplot as plt
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.multi_term_atom_model.object.level_registry import LevelRegistry
 from solrat.atom_model.multi_term_atom_model.utility.paschen_back import (
     calculate_paschen_back,
     get_artificial_S_scale_from_term_g,
 )
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 
 
 def main():
@@ -16,7 +16,7 @@ def main():
     This demo shows the calculation of the Zeeman splitting for the Fe I 5434 A line.
     """
 
-    logging_config.init(logging.INFO)
+    setup_logging(logging.INFO)
 
     level_registry = LevelRegistry()
     level_registry.register_level(

--- a/_demos/general/demo_paschen_back_FeI5434.py
+++ b/_demos/general/demo_paschen_back_FeI5434.py
@@ -1,5 +1,3 @@
-import logging
-
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -16,7 +14,7 @@ def main():
     This demo shows the calculation of the Zeeman splitting for the Fe I 5434 A line.
     """
 
-    setup_logging(logging.INFO)
+    setup_logging()
 
     level_registry = LevelRegistry()
     level_registry.register_level(

--- a/_demos/general/demo_voigt_profile.py
+++ b/_demos/general/demo_voigt_profile.py
@@ -2,9 +2,9 @@ import logging
 
 import matplotlib.pyplot as plt
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.shared.utility.constants import c_cm_sm1, sqrt_pi
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 from solrat.atom_model.shared.utility.voigt_profile import voigt
 
 
@@ -13,7 +13,7 @@ def main():
     Reference: (LL04 5.43)
     This corresponds to Fig. 5.3.
     """
-    logging_config.init(logging.INFO)
+    setup_logging(logging.INFO)
 
     nu0 = 5.996e14  # Hz
 

--- a/_demos/general/demo_voigt_profile.py
+++ b/_demos/general/demo_voigt_profile.py
@@ -1,5 +1,3 @@
-import logging
-
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -13,7 +11,7 @@ def main():
     Reference: (LL04 5.43)
     This corresponds to Fig. 5.3.
     """
-    setup_logging(logging.INFO)
+    setup_logging()
 
     nu0 = 5.996e14  # Hz
 

--- a/_demos/multi_term_atom/demo_constant_property_slab_HeI_D3.py
+++ b/_demos/multi_term_atom/demo_constant_property_slab_HeI_D3.py
@@ -9,7 +9,7 @@ from solrat.atom_model.shared.common_api.multi_slab_atmosphere import MultiSlabA
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.object.stokes import Stokes
 from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
-from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesPlotter
+from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesNorm, StokesPlotter
 
 
 def main():
@@ -36,7 +36,7 @@ def main():
         theta_B=0,
     )
 
-    plotter = StokesPlotter("He I D3 transition for different magnetic field values")
+    plotter = StokesPlotter("He I D3 transition for different magnetic field values", vacuum_to_air=True)
 
     for Bz in [0, 3000, 5000]:
         atmosphere_parameters = model.AtmosphereParameters(
@@ -63,10 +63,10 @@ def main():
 
         plotter.add_stokes(
             lambda_A=lambda_A,
-            reference_lambda_A=reference_lambda,
+            lambda_ref_A=reference_lambda,
             stokes=atmosphere.forward(initial_stokes=initial_stokes),
+            norm=StokesNorm.MAX_I,
             label=f"B = {Bz} G",
-            normalize=True,
         )
 
     plotter.show()

--- a/_demos/multi_term_atom/demo_constant_property_slab_HeI_D3.py
+++ b/_demos/multi_term_atom/demo_constant_property_slab_HeI_D3.py
@@ -1,15 +1,15 @@
 import logging
 
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.common_api.constant_property_slab import ConstantPropertySlabAtmosphere
 from solrat.atom_model.shared.common_api.multi_slab_atmosphere import MultiSlabAtmosphere
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.object.stokes import Stokes
-from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
-from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesNorm, StokesPlotter
+from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range
+from solrat.atom_model.shared.utility.log_setup import setup_logging
+from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesPlotter
 
 
 def main():
@@ -19,14 +19,15 @@ def main():
     https://doi.org/10.1093/mnras/stad1816, where these profiles were obtained using HAZEL2.
     """
 
-    logging_config.init(logging.INFO)
+    setup_logging(logging.INFO)
 
     model = PreconfiguredModels.multi_term_atom_HeID3()
-    reference_lambda = model.config.reference_lambda_A
-
-    # The calculation itself needs frequency, but we will display the results in wavelength
-    lambda_A = np.arange(reference_lambda - 0.5, reference_lambda + 0.8, 5e-4)
-    nu = lambda_A_to_frequency_hz(lambda_A)
+    reference_lambda_A_air = model.config.reference_lambda_A_air
+    nu = get_frequencies_from_air_wavelength_range(
+        lower_wavelength_A=reference_lambda_A_air - 0.5,
+        upper_wavelength_A=reference_lambda_A_air + 0.8,
+        step_A=5e-4,
+    )
 
     angles = Angles(
         chi=0,
@@ -36,7 +37,9 @@ def main():
         theta_B=0,
     )
 
-    plotter = StokesPlotter("He I D3 transition for different magnetic field values", vacuum_to_air=True)
+    plotter = StokesPlotter(
+        "He I D3 transition for different magnetic field values", reference_lambda_A_air=reference_lambda_A_air
+    )
 
     for Bz in [0, 3000, 5000]:
         atmosphere_parameters = model.AtmosphereParameters(
@@ -62,10 +65,9 @@ def main():
         )
 
         plotter.add_stokes(
-            lambda_A=lambda_A,
-            lambda_ref_A=reference_lambda,
+            nu=nu,
             stokes=atmosphere.forward(initial_stokes=initial_stokes),
-            norm=StokesNorm.MAX_I,
+            norm=StokesPlotter.Norm.MAX_I,
             label=f"B = {Bz} G",
         )
 

--- a/_demos/multi_term_atom/demo_constant_property_slab_HeI_D3.py
+++ b/_demos/multi_term_atom/demo_constant_property_slab_HeI_D3.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 
 from solrat.atom_model.model_registry import PreconfiguredModels
@@ -19,7 +17,7 @@ def main():
     https://doi.org/10.1093/mnras/stad1816, where these profiles were obtained using HAZEL2.
     """
 
-    setup_logging(logging.INFO)
+    setup_logging()
 
     model = PreconfiguredModels.multi_term_atom_HeID3()
     reference_lambda_A_air = model.config.reference_lambda_A_air

--- a/_demos/multi_term_atom/demo_hanle_effect.py
+++ b/_demos/multi_term_atom/demo_hanle_effect.py
@@ -1,0 +1,83 @@
+import logging
+
+import numpy as np
+from matplotlib import pyplot as plt
+from yatools import logging_config
+
+from solrat.atom_model.model_registry import PreconfiguredModels
+from solrat.atom_model.shared.object.angles import Angles
+
+
+def main():
+    r"""
+    Hanle effect: depolarization of the upper-state Q=2 coherence as a function
+    of magnetic field strength. Critical magnetic field is approximately
+    A_ul / (Q × 2π × g_J × ν_L/G) = 4.3 G
+    """
+    logging_config.init(logging.INFO)
+
+    model = PreconfiguredModels.multi_term_atom_mock()
+
+    angles = Angles(
+        chi=0,
+        theta=np.pi / 4,
+        gamma=0,
+        chi_B=0,
+        theta_B=np.pi / 2,
+    )
+
+    radiation_tensor_mag = (
+        model.RadiationTensor.from_model_config(model.config)
+        .fill_NLTE_n_w_parametrized(h_arcsec=30)
+        .rotate_to_magnetic_frame(angles=angles)
+    )
+
+    see = model.StatisticalEquilibriumEquations.from_model_config(model.config)
+
+    upper_term = model.config.level_registry.get_term(beta="2p", L=1, S=0.5)
+    J_align = 1.5
+
+    B_values = np.linspace(0, 20, 100)
+    alignments = []
+
+    for B in B_values:
+        atmosphere_parameters = model.AtmosphereParameters(
+            model_config=model.config,
+            magnetic_field_gauss=float(B),
+            temperature_K=7000,
+        )
+        see.fill_all_equations(
+            atmosphere_parameters=atmosphere_parameters,
+            radiation_tensor_in_magnetic_frame=radiation_tensor_mag,
+        )
+        rho = see.get_solution()
+        alignments.append(
+            np.abs(
+                rho(
+                    term_id=upper_term.term_id,
+                    K=2,
+                    Q=2,
+                    J=J_align,
+                    Jʹ=J_align,
+                )
+            )
+        )
+
+    alignments = np.array(alignments)
+    scale = alignments[0]
+    alignments_norm = alignments / scale
+
+    fig, ax = plt.subplots(figsize=(7, 4), num="Hanle Effect")
+    ax.plot(B_values, alignments_norm, lw=2, label=r"$|\rho^2_2(J=1.5,\,J'=1.5)|\,/\,|\rho^2_2(B{=}0)|$")
+    ax.axhline(1 / np.sqrt(2), color="gray", linestyle="--", lw=1, label="1/sqrt(2) level")
+    ax.set_xlabel("Magnetic field B (G)")
+    ax.set_ylabel("Normalised alignment modulus")
+    ax.set_title("Hanle effect - upper-state Q=2 coherence vs magnetic field")
+    ax.legend()
+    ax.grid(True)
+    fig.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/_demos/multi_term_atom/demo_hanle_effect.py
+++ b/_demos/multi_term_atom/demo_hanle_effect.py
@@ -2,10 +2,10 @@ import logging
 
 import numpy as np
 from matplotlib import pyplot as plt
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.object.angles import Angles
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 
 
 def main():
@@ -14,7 +14,7 @@ def main():
     of magnetic field strength. Critical magnetic field is approximately
     A_ul / (Q × 2π × g_J × ν_L/G) = 4.3 G
     """
-    logging_config.init(logging.INFO)
+    setup_logging(logging.INFO)
 
     model = PreconfiguredModels.multi_term_atom_mock()
 

--- a/_demos/multi_term_atom/demo_hanle_effect.py
+++ b/_demos/multi_term_atom/demo_hanle_effect.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 from matplotlib import pyplot as plt
 
@@ -14,7 +12,7 @@ def main():
     of magnetic field strength. Critical magnetic field is approximately
     A_ul / (Q × 2π × g_J × ν_L/G) = 4.3 G
     """
-    setup_logging(logging.INFO)
+    setup_logging()
 
     model = PreconfiguredModels.multi_term_atom_mock()
 

--- a/_demos/multi_term_atom/demo_radiative_transfer_equations_D3.py
+++ b/_demos/multi_term_atom/demo_radiative_transfer_equations_D3.py
@@ -76,7 +76,7 @@ def main():
             lambda_A=lambda_A,
             stokes_I=rtc.get_epsilon_I(),
             stokes_V=rtc.get_epsilon_V(),
-            reference_lambda_A=reference_lambda,
+            lambda_ref_A=reference_lambda,
             color="auto",
             label=rf"$B_z = {Bz/1000:.0f}$ kG",
         )

--- a/_demos/multi_term_atom/demo_radiative_transfer_equations_D3.py
+++ b/_demos/multi_term_atom/demo_radiative_transfer_equations_D3.py
@@ -1,11 +1,9 @@
 import logging
 
-import numpy as np
-from yatools import logging_config
-
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.object.angles import Angles
-from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
+from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesPlotter_IV
 
 
@@ -19,14 +17,15 @@ def main():
     but they match (after normalization) eta_S for low optical depths.
     """
 
-    logging_config.init(logging.INFO)
+    setup_logging(logging.INFO)
 
     model = PreconfiguredModels.multi_term_atom_HeID3()
-    reference_lambda = model.config.reference_lambda_A
-
-    # The calculation itself needs frequency, but we will display the results in wavelength
-    lambda_A = np.arange(reference_lambda - 2, reference_lambda + 2, 5e-4)
-    nu = lambda_A_to_frequency_hz(lambda_A)
+    reference_lambda_A_air = model.config.reference_lambda_A_air
+    nu = get_frequencies_from_air_wavelength_range(
+        lower_wavelength_A=reference_lambda_A_air - 2,
+        upper_wavelength_A=reference_lambda_A_air + 2,
+        step_A=5e-4,
+    )
 
     angles = Angles(
         chi=0,
@@ -45,7 +44,9 @@ def main():
     )
 
     # Set up the plotter
-    plotter = StokesPlotter_IV(title="He I D3: Emission coefficient vs wavelength")
+    plotter = StokesPlotter_IV(
+        title="He I D3: Emission coefficient vs wavelength", reference_lambda_A_air=reference_lambda_A_air
+    )
 
     # loop through the magnetic field values
     for Bz in [20000, 40000, 60000, 80000, 100000]:
@@ -73,10 +74,9 @@ def main():
 
         # Plot emission coefficient
         plotter.add(
-            lambda_A=lambda_A,
+            nu=nu,
             stokes_I=rtc.get_epsilon_I(),
             stokes_V=rtc.get_epsilon_V(),
-            lambda_ref_A=reference_lambda,
             color="auto",
             label=rf"$B_z = {Bz/1000:.0f}$ kG",
         )

--- a/_demos/multi_term_atom/demo_radiative_transfer_equations_D3.py
+++ b/_demos/multi_term_atom/demo_radiative_transfer_equations_D3.py
@@ -1,5 +1,3 @@
-import logging
-
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range
@@ -17,7 +15,7 @@ def main():
     but they match (after normalization) eta_S for low optical depths.
     """
 
-    setup_logging(logging.INFO)
+    setup_logging()
 
     model = PreconfiguredModels.multi_term_atom_HeID3()
     reference_lambda_A_air = model.config.reference_lambda_A_air

--- a/_demos/multi_term_atom/demo_radiative_transfer_equations_D3_parameter_sweep.py
+++ b/_demos/multi_term_atom/demo_radiative_transfer_equations_D3_parameter_sweep.py
@@ -1,12 +1,9 @@
 import logging
 
-import matplotlib.pyplot as plt
-import numpy as np
-from yatools import logging_config
-
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.object.angles import Angles
-from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
+from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesPlotter_IV
 
 
@@ -20,25 +17,15 @@ def main():
     but they match (after normalization) eta_S for low optical depths.
     """
 
-    logging_config.init(logging.INFO)
-
-    plt.rcParams.update(
-        {
-            "font.size": 16,
-            "axes.titlesize": 16,
-            "axes.labelsize": 18,
-            "xtick.labelsize": 16,
-            "ytick.labelsize": 16,
-            "legend.fontsize": 16,
-        }
-    )
+    setup_logging(logging.INFO)
 
     model = PreconfiguredModels.multi_term_atom_HeID3()
-    reference_lambda = model.config.reference_lambda_A
-
-    # The calculation itself needs frequency, but we will display the results in wavelength
-    lambda_A = np.arange(reference_lambda - 0.2, reference_lambda + 0.5, 2e-4)
-    nu = lambda_A_to_frequency_hz(lambda_A)
+    reference_lambda_A_air = model.config.reference_lambda_A_air
+    nu = get_frequencies_from_air_wavelength_range(
+        lower_wavelength_A=reference_lambda_A_air - 0.2,
+        upper_wavelength_A=reference_lambda_A_air + 0.5,
+        step_A=2e-3,
+    )
 
     angles = Angles(
         chi=0,
@@ -52,12 +39,12 @@ def main():
     rte = model.RadiativeTransferEquations.from_model_config(model.config, nu=nu)
 
     # Fill the radiation tensor with anisotropic radiation field 10 arcsec from the Sun's apparent surface
-    radiation_tensor = model.RadiationTensor.from_model_config(model.config).fill_NLTE_n_w_parametrized(
-        h_arcsec=10,
-    )
+    radiation_tensor = model.RadiationTensor.from_model_config(model.config).fill_NLTE_n_w_parametrized(h_arcsec=10)
 
     # Set up the plotter
-    plotter = StokesPlotter_IV()
+    plotter = StokesPlotter_IV(
+        "He I D3 emission at different magnetic fields", reference_lambda_A_air=reference_lambda_A_air
+    )
 
     # loop through the magnetic field values
     for Bz in [0, 500, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000]:
@@ -85,17 +72,14 @@ def main():
 
         # Plot emission coefficient
         plotter.add(
-            lambda_A=lambda_A,
+            nu=nu,
             stokes_I=rtc.get_epsilon_I(),
             stokes_V=rtc.get_epsilon_V(),
-            lambda_ref_A=reference_lambda,
             color="auto",
             label=rf"$B_z = {Bz/1000:.1f}$ kG",
             linewidth=2,
         )
 
-    plt.gcf().align_ylabels()
-    plt.suptitle("He I D3 emission at different magnetic fields")
     plotter.show()
 
 

--- a/_demos/multi_term_atom/demo_radiative_transfer_equations_D3_parameter_sweep.py
+++ b/_demos/multi_term_atom/demo_radiative_transfer_equations_D3_parameter_sweep.py
@@ -1,5 +1,3 @@
-import logging
-
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range
@@ -17,7 +15,7 @@ def main():
     but they match (after normalization) eta_S for low optical depths.
     """
 
-    setup_logging(logging.INFO)
+    setup_logging()
 
     model = PreconfiguredModels.multi_term_atom_HeID3()
     reference_lambda_A_air = model.config.reference_lambda_A_air

--- a/_demos/multi_term_atom/demo_radiative_transfer_equations_D3_parameter_sweep.py
+++ b/_demos/multi_term_atom/demo_radiative_transfer_equations_D3_parameter_sweep.py
@@ -14,7 +14,7 @@ def main():
     """
     This demo shows the calculation of stimulated emission eta_S profiles
     for the He I D3 transition under super-strong magnetic fields.
-    This result is closely related to Fig. 8 in Yakovkin & Lozitsky (MNRAS, 2023)
+    This result is related to Fig. 8 in Yakovkin & Lozitsky (MNRAS, 2023)
     https://doi.org/10.1093/mnras/stad1816, where these profiles were obtained using HAZEL2.
     In the mentioned paper, the Stokes profiles are shown instead,
     but they match (after normalization) eta_S for low optical depths.
@@ -88,7 +88,7 @@ def main():
             lambda_A=lambda_A,
             stokes_I=rtc.get_epsilon_I(),
             stokes_V=rtc.get_epsilon_V(),
-            reference_lambda_A=reference_lambda,
+            lambda_ref_A=reference_lambda,
             color="auto",
             label=rf"$B_z = {Bz/1000:.1f}$ kG",
             linewidth=2,

--- a/_demos/multi_term_atom/demo_radiative_transfer_equations_resonance.py
+++ b/_demos/multi_term_atom/demo_radiative_transfer_equations_resonance.py
@@ -84,21 +84,21 @@ def main():
     )
 
     plotter.add(
-        nu,
-        0,
-        np.real(rtc.eta_rho_sI) / np.max(np.abs(eta_sI_analytic)),
-        np.real(rtc.eta_rho_sQ) / np.max(np.abs(eta_sI_analytic)),
-        np.real(rtc.eta_rho_sU) / np.max(np.abs(eta_sI_analytic)),
-        np.real(rtc.eta_rho_sV) / np.max(np.abs(eta_sI_analytic)),
+        lambda_A=nu,
+        lambda_ref_A=0,
+        stokes_I=np.real(rtc.eta_rho_sI) / np.max(np.abs(eta_sI_analytic)),
+        stokes_Q=np.real(rtc.eta_rho_sQ) / np.max(np.abs(eta_sI_analytic)),
+        stokes_U=np.real(rtc.eta_rho_sU) / np.max(np.abs(eta_sI_analytic)),
+        stokes_V=np.real(rtc.eta_rho_sV) / np.max(np.abs(eta_sI_analytic)),
         label="SEE+RTE implementation",
     )
     plotter.add(
-        nu,
-        0,
-        eta_sI_analytic / np.max(np.abs(eta_sI_analytic)),
-        eta_sQ_analytic / np.max(np.abs(eta_sI_analytic)),
-        eta_sU_analytic / np.max(np.abs(eta_sI_analytic)),
-        eta_sV_analytic / np.max(np.abs(eta_sI_analytic)),
+        lambda_A=nu,
+        lambda_ref_A=0,
+        stokes_I=eta_sI_analytic / np.max(np.abs(eta_sI_analytic)),
+        stokes_Q=eta_sQ_analytic / np.max(np.abs(eta_sI_analytic)),
+        stokes_U=eta_sU_analytic / np.max(np.abs(eta_sI_analytic)),
+        stokes_V=eta_sV_analytic / np.max(np.abs(eta_sI_analytic)),
         label="Analytical solution",
         style="--",
         linewidth=2,

--- a/_demos/multi_term_atom/demo_radiative_transfer_equations_resonance.py
+++ b/_demos/multi_term_atom/demo_radiative_transfer_equations_resonance.py
@@ -1,11 +1,11 @@
 import logging
 
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.object.angles import Angles
-from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
+from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesPlotter
 
 
@@ -19,12 +19,15 @@ def main():
     Reference: (LL04 10.127)
     """
 
-    logging_config.init(logging.INFO)
+    setup_logging(logging.INFO)
 
     model = PreconfiguredModels.multi_term_atom_mock()
-    reference_nu = lambda_A_to_frequency_hz(model.config.reference_lambda_A)
-
-    nu = np.arange(reference_nu - 1e11, reference_nu + 1e11, 1e8)  # Hz
+    reference_lambda_A_air = model.config.reference_lambda_A_air
+    nu = get_frequencies_from_air_wavelength_range(
+        lower_wavelength_A=reference_lambda_A_air - 1,
+        upper_wavelength_A=reference_lambda_A_air + 1,
+        step_A=2e-3,
+    )
 
     angles = Angles(
         chi=0,
@@ -48,7 +51,7 @@ def main():
         delta_v_turbulent_cm_sm1=50_00,
     )
 
-    plotter = StokesPlotter(r"$\eta_s$ vs Frequency", x_label=r"$\nu$ (1/s)")
+    plotter = StokesPlotter(r"$\eta_s$ vs Wavelength", reference_lambda_A_air=reference_lambda_A_air)
 
     # Construct SEE
     see.fill_all_equations(
@@ -84,8 +87,7 @@ def main():
     )
 
     plotter.add(
-        lambda_A=nu,
-        lambda_ref_A=0,
+        nu=nu,
         stokes_I=np.real(rtc.eta_rho_sI) / np.max(np.abs(eta_sI_analytic)),
         stokes_Q=np.real(rtc.eta_rho_sQ) / np.max(np.abs(eta_sI_analytic)),
         stokes_U=np.real(rtc.eta_rho_sU) / np.max(np.abs(eta_sI_analytic)),
@@ -93,13 +95,12 @@ def main():
         label="SEE+RTE implementation",
     )
     plotter.add(
-        lambda_A=nu,
-        lambda_ref_A=0,
+        nu=nu,
         stokes_I=eta_sI_analytic / np.max(np.abs(eta_sI_analytic)),
         stokes_Q=eta_sQ_analytic / np.max(np.abs(eta_sI_analytic)),
         stokes_U=eta_sU_analytic / np.max(np.abs(eta_sI_analytic)),
         stokes_V=eta_sV_analytic / np.max(np.abs(eta_sI_analytic)),
-        label="Analytical solution",
+        label="Analytic solution",
         style="--",
         linewidth=2,
     )

--- a/_demos/multi_term_atom/demo_radiative_transfer_equations_resonance.py
+++ b/_demos/multi_term_atom/demo_radiative_transfer_equations_resonance.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 
 from solrat.atom_model.model_registry import PreconfiguredModels
@@ -19,7 +17,7 @@ def main():
     Reference: (LL04 10.127)
     """
 
-    setup_logging(logging.INFO)
+    setup_logging()
 
     model = PreconfiguredModels.multi_term_atom_mock()
     reference_lambda_A_air = model.config.reference_lambda_A_air

--- a/_demos/multi_term_atom_lte/demo_constant_property_slab_MnI.py
+++ b/_demos/multi_term_atom_lte/demo_constant_property_slab_MnI.py
@@ -1,5 +1,3 @@
-import logging
-
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.common_api.constant_property_slab import ConstantPropertySlabAtmosphere
 from solrat.atom_model.shared.common_api.multi_slab_atmosphere import MultiSlabAtmosphere
@@ -14,7 +12,7 @@ def demo_constant_property_slab_MnI():
     """
     Demonstrate basic usage of ConstantPropertySlab for Mn I LTE line synthesis.
     """
-    setup_logging(logging.INFO)
+    setup_logging()
 
     model = PreconfiguredModels.multi_term_atom_lte_MnI_5432()
     reference_lambda_A_air = model.config.reference_lambda_A_air

--- a/_demos/multi_term_atom_lte/demo_constant_property_slab_MnI.py
+++ b/_demos/multi_term_atom_lte/demo_constant_property_slab_MnI.py
@@ -1,37 +1,37 @@
 import logging
 
-import numpy as np
-from yatools import logging_config
-
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.common_api.constant_property_slab import ConstantPropertySlabAtmosphere
 from solrat.atom_model.shared.common_api.multi_slab_atmosphere import MultiSlabAtmosphere
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.object.stokes import Stokes
-from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
-from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesNorm, StokesPlotter_IV_IpmV
+from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range
+from solrat.atom_model.shared.utility.log_setup import setup_logging
+from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesPlotter_IV_IpmV
 
 
 def demo_constant_property_slab_MnI():
     """
     Demonstrate basic usage of ConstantPropertySlab for Mn I LTE line synthesis.
     """
-    logging_config.init(logging.INFO)
+    setup_logging(logging.INFO)
 
     model = PreconfiguredModels.multi_term_atom_lte_MnI_5432()
-    reference_lambda = model.config.reference_lambda_A
-
-    lambda_A = np.arange(reference_lambda - 0.5, reference_lambda + 0.5, 1e-3)
-    nu = lambda_A_to_frequency_hz(lambda_A)
+    reference_lambda_A_air = model.config.reference_lambda_A_air
+    nu = get_frequencies_from_air_wavelength_range(
+        lower_wavelength_A=reference_lambda_A_air - 0.2,
+        upper_wavelength_A=reference_lambda_A_air + 0.2,
+        step_A=1e-3,
+    )
 
     # Test different magnetic field strengths
-    plotter = StokesPlotter_IV_IpmV("Mn I 5432 Line")
+    plotter = StokesPlotter_IV_IpmV("Mn I 5432 Line", reference_lambda_A_air=reference_lambda_A_air)
 
     angles = Angles(chi=0, theta=0, gamma=0, chi_B=0, theta_B=0)
 
     # Atmosphere parameters:
     atmosphere1 = {
-        "magnetic_field_gauss": 1000,
+        "magnetic_field_gauss": 500,
         "temperature_K": 5000,
         "delta_v_turbulent_cm_sm1": 1000_00,
         "macroscopic_velocity_cm_sm1": 0,
@@ -57,23 +57,10 @@ def demo_constant_property_slab_MnI():
     stokes_Mn = atmosphere_Mn.forward(initial_stokes=initial_stokes)
 
     plotter.add_stokes(
-        lambda_A=np.concat([lambda_A]),
-        lambda_ref_A=reference_lambda,
-        norm=StokesNorm.BY_REFERENCE,
-        stokes=Stokes(
-            nu=np.concat([stokes_Mn.nu]),
-            I=np.concat([stokes_Mn.I]),
-            Q=np.concat([stokes_Mn.Q]),
-            U=np.concat([stokes_Mn.U]),
-            V=np.concat([stokes_Mn.V]),
-        ),
-        stokes_reference=Stokes(
-            nu=np.concat([initial_stokes.nu]),
-            I=np.concat([initial_stokes.I]),
-            Q=np.concat([initial_stokes.Q]),
-            U=np.concat([initial_stokes.U]),
-            V=np.concat([initial_stokes.V]),
-        ),
+        nu=nu,
+        norm=StokesPlotter_IV_IpmV.Norm.BY_REFERENCE,
+        stokes=stokes_Mn,
+        stokes_reference=initial_stokes,
         label="RTE with LTE SEE",
     )
 

--- a/_demos/multi_term_atom_lte/demo_constant_property_slab_MnI.py
+++ b/_demos/multi_term_atom_lte/demo_constant_property_slab_MnI.py
@@ -9,7 +9,7 @@ from solrat.atom_model.shared.common_api.multi_slab_atmosphere import MultiSlabA
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.object.stokes import Stokes
 from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
-from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesPlotter_IV_IpmV
+from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesNorm, StokesPlotter_IV_IpmV
 
 
 def demo_constant_property_slab_MnI():
@@ -21,7 +21,7 @@ def demo_constant_property_slab_MnI():
     model = PreconfiguredModels.multi_term_atom_lte_MnI_5432()
     reference_lambda = model.config.reference_lambda_A
 
-    lambda_A = np.arange(reference_lambda + 1.4, reference_lambda + 1.7, 1e-3)
+    lambda_A = np.arange(reference_lambda - 0.5, reference_lambda + 0.5, 1e-3)
     nu = lambda_A_to_frequency_hz(lambda_A)
 
     # Test different magnetic field strengths
@@ -58,7 +58,8 @@ def demo_constant_property_slab_MnI():
 
     plotter.add_stokes(
         lambda_A=np.concat([lambda_A]),
-        reference_lambda_A=1.5,
+        lambda_ref_A=reference_lambda,
+        norm=StokesNorm.BY_REFERENCE,
         stokes=Stokes(
             nu=np.concat([stokes_Mn.nu]),
             I=np.concat([stokes_Mn.I]),

--- a/_demos/multi_term_atom_lte/demo_constant_property_slab_MnI_FeI_NiI.py
+++ b/_demos/multi_term_atom_lte/demo_constant_property_slab_MnI_FeI_NiI.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 
 from solrat.atom_model.model_registry import PreconfiguredModels
@@ -17,7 +15,7 @@ def demo_constant_property_slab_multiline():
     """
     Demonstrate basic usage of ConstantPropertySlab for multiple non-overlapping line synthesis.
     """
-    setup_logging(logging.INFO)
+    setup_logging()
 
     model_Mn = PreconfiguredModels.multi_term_atom_lte_MnI_5432()
     model_Fe = PreconfiguredModels.multi_term_atom_lte_FeI_5434()

--- a/_demos/multi_term_atom_lte/demo_constant_property_slab_MnI_FeI_NiI.py
+++ b/_demos/multi_term_atom_lte/demo_constant_property_slab_MnI_FeI_NiI.py
@@ -1,7 +1,6 @@
 import logging
 
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.multi_term_atom_model.object.atmosphere_parameters import AtmosphereParameters
@@ -9,38 +8,47 @@ from solrat.atom_model.shared.common_api.constant_property_slab import ConstantP
 from solrat.atom_model.shared.common_api.multi_slab_atmosphere import MultiSlabAtmosphere
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.object.stokes import Stokes
-from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
-from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesNorm, StokesPlotter_IV_IpmV
+from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range
+from solrat.atom_model.shared.utility.log_setup import setup_logging
+from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesPlotter_IV_IpmV
 
 
 def demo_constant_property_slab_multiline():
     """
     Demonstrate basic usage of ConstantPropertySlab for multiple non-overlapping line synthesis.
     """
-    logging_config.init(logging.INFO)
+    setup_logging(logging.INFO)
 
     model_Mn = PreconfiguredModels.multi_term_atom_lte_MnI_5432()
     model_Fe = PreconfiguredModels.multi_term_atom_lte_FeI_5434()
     model_Ni = PreconfiguredModels.multi_term_atom_lte_NiI_5435()
 
-    reference_lambda_Mn = model_Mn.config.reference_lambda_A
-    reference_lambda_Fe = model_Fe.config.reference_lambda_A
-    reference_lambda_Ni = model_Ni.config.reference_lambda_A
+    reference_lambda_A_Mn = model_Mn.config.reference_lambda_A_air
+    reference_lambda_A_Fe = model_Fe.config.reference_lambda_A_air
+    reference_lambda_A_Ni = model_Ni.config.reference_lambda_A_air
 
-    lambda_A_Mn = np.arange(reference_lambda_Mn - 0.5, reference_lambda_Mn + 0.5, 1e-3)
-    lambda_A_Fe = np.arange(reference_lambda_Fe - 0.5, reference_lambda_Fe + 0.5, 1e-3)
-    lambda_A_Ni = np.arange(reference_lambda_Ni - 0.5, reference_lambda_Ni + 0.5, 1e-3)
-
-    nu_Mn = lambda_A_to_frequency_hz(lambda_A_Mn)
-    nu_Fe = lambda_A_to_frequency_hz(lambda_A_Fe)
-    nu_Ni = lambda_A_to_frequency_hz(lambda_A_Ni)
+    nu_Mn = get_frequencies_from_air_wavelength_range(
+        lower_wavelength_A=reference_lambda_A_Mn - 0.5,
+        upper_wavelength_A=reference_lambda_A_Mn + 0.5,
+        step_A=1e-3,
+    )
+    nu_Fe = get_frequencies_from_air_wavelength_range(
+        lower_wavelength_A=reference_lambda_A_Fe - 0.5,
+        upper_wavelength_A=reference_lambda_A_Fe + 0.5,
+        step_A=1e-3,
+    )
+    nu_Ni = get_frequencies_from_air_wavelength_range(
+        lower_wavelength_A=reference_lambda_A_Ni - 0.5,
+        upper_wavelength_A=reference_lambda_A_Ni + 0.5,
+        step_A=1e-3,
+    )
 
     radiation_tensor_Mn = model_Mn.RadiationTensor()
     radiation_tensor_Fe = model_Fe.RadiationTensor()
     radiation_tensor_Ni = model_Ni.RadiationTensor()
 
     # Test different magnetic field strengths
-    plotter = StokesPlotter_IV_IpmV("Mn, Fe, and Ni lines:")
+    plotter = StokesPlotter_IV_IpmV("Mn, Fe, and Ni lines:", reference_lambda_A_air=reference_lambda_A_Mn)
 
     angles = Angles(chi=0, theta=0, gamma=0, chi_B=0, theta_B=0)
 
@@ -157,9 +165,8 @@ def demo_constant_property_slab_multiline():
     stokes_Ni = atmosphere_Ni.forward(initial_stokes=initial_stokes_Ni)
 
     plotter.add_stokes(
-        lambda_A=np.concat([lambda_A_Mn, lambda_A_Fe, lambda_A_Ni]),
-        lambda_ref_A=reference_lambda_Mn,
-        norm=StokesNorm.BY_REFERENCE,
+        nu=np.concat([nu_Mn, nu_Fe, nu_Ni]),
+        norm=StokesPlotter_IV_IpmV.Norm.BY_REFERENCE,
         stokes=Stokes(
             nu=np.concat([stokes_Mn.nu, stokes_Fe.nu, stokes_Ni.nu]),
             I=np.concat([stokes_Mn.I, stokes_Fe.I, stokes_Ni.I]),

--- a/_demos/multi_term_atom_lte/demo_constant_property_slab_MnI_FeI_NiI.py
+++ b/_demos/multi_term_atom_lte/demo_constant_property_slab_MnI_FeI_NiI.py
@@ -10,7 +10,7 @@ from solrat.atom_model.shared.common_api.multi_slab_atmosphere import MultiSlabA
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.object.stokes import Stokes
 from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
-from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesPlotter_IV_IpmV
+from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesNorm, StokesPlotter_IV_IpmV
 
 
 def demo_constant_property_slab_multiline():
@@ -27,9 +27,9 @@ def demo_constant_property_slab_multiline():
     reference_lambda_Fe = model_Fe.config.reference_lambda_A
     reference_lambda_Ni = model_Ni.config.reference_lambda_A
 
-    lambda_A_Mn = np.arange(reference_lambda_Mn + 1.5 - 0.5, reference_lambda_Mn + 1.5 + 0.5, 1e-3)
-    lambda_A_Fe = np.arange(reference_lambda_Fe + 1.5 - 0.5, reference_lambda_Fe + 1.5 + 0.5, 1e-3)
-    lambda_A_Ni = np.arange(reference_lambda_Ni + 1.5 - 0.5, reference_lambda_Ni + 1.5 + 0.5, 1e-3)
+    lambda_A_Mn = np.arange(reference_lambda_Mn - 0.5, reference_lambda_Mn + 0.5, 1e-3)
+    lambda_A_Fe = np.arange(reference_lambda_Fe - 0.5, reference_lambda_Fe + 0.5, 1e-3)
+    lambda_A_Ni = np.arange(reference_lambda_Ni - 0.5, reference_lambda_Ni + 0.5, 1e-3)
 
     nu_Mn = lambda_A_to_frequency_hz(lambda_A_Mn)
     nu_Fe = lambda_A_to_frequency_hz(lambda_A_Fe)
@@ -158,7 +158,8 @@ def demo_constant_property_slab_multiline():
 
     plotter.add_stokes(
         lambda_A=np.concat([lambda_A_Mn, lambda_A_Fe, lambda_A_Ni]),
-        reference_lambda_A=1.5,
+        lambda_ref_A=reference_lambda_Mn,
+        norm=StokesNorm.BY_REFERENCE,
         stokes=Stokes(
             nu=np.concat([stokes_Mn.nu, stokes_Fe.nu, stokes_Ni.nu]),
             I=np.concat([stokes_Mn.I, stokes_Fe.I, stokes_Ni.I]),

--- a/_demos/multi_term_atom_lte/demo_stokes_vs_B_lte_MnI.py
+++ b/_demos/multi_term_atom_lte/demo_stokes_vs_B_lte_MnI.py
@@ -1,34 +1,34 @@
 import logging
 
-import numpy as np
-from yatools import logging_config
-
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.common_api.constant_property_slab import ConstantPropertySlabAtmosphere
 from solrat.atom_model.shared.common_api.multi_slab_atmosphere import MultiSlabAtmosphere
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.object.stokes import Stokes
-from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
-from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesNorm, StokesPlotter_IV_IpmV
+from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range
+from solrat.atom_model.shared.utility.log_setup import setup_logging
+from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesPlotter_IV_IpmV
 
 
 def main():
     """
     Zeeman effect in the Mn I 5432 A line (LTE) for a range of magnetic field strengths.
     """
-    logging_config.init(logging.INFO)
+    setup_logging(logging.INFO)
 
     model = PreconfiguredModels.multi_term_atom_lte_MnI_5432()
-
-    reference_lambda = model.config.reference_lambda_A
-    lambda_A = np.arange(reference_lambda - 0.6, reference_lambda + 0.6, 0.005)
-    nu = lambda_A_to_frequency_hz(lambda_A)
+    reference_lambda_A_air = model.config.reference_lambda_A_air
+    nu = get_frequencies_from_air_wavelength_range(
+        lower_wavelength_A=reference_lambda_A_air - 0.2,
+        upper_wavelength_A=reference_lambda_A_air + 0.2,
+        step_A=0.001,
+    )
 
     angles = Angles(chi=0, theta=0, gamma=0, chi_B=0, theta_B=0)
 
     initial_stokes = Stokes.from_BP(nu_sm1=nu, temperature_K=5700)
 
-    plotter = StokesPlotter_IV_IpmV("Mn I 5432 — Zeeman effect (LTE)")
+    plotter = StokesPlotter_IV_IpmV("Mn I 5432: Zeeman effect (LTE)", reference_lambda_A_air=reference_lambda_A_air)
 
     for B in [0, 500, 1000, 2000]:
         atmosphere_parameters = model.AtmosphereParameters(
@@ -52,10 +52,9 @@ def main():
         stokes = atmosphere.forward(initial_stokes=initial_stokes)
 
         plotter.add_stokes(
-            lambda_A=lambda_A,
-            lambda_ref_A=reference_lambda,
+            nu=nu,
             stokes=stokes,
-            norm=StokesNorm.BY_REFERENCE,
+            norm=StokesPlotter_IV_IpmV.Norm.BY_REFERENCE,
             stokes_reference=initial_stokes,
             label=f"B = {B} G",
         )

--- a/_demos/multi_term_atom_lte/demo_stokes_vs_B_lte_MnI.py
+++ b/_demos/multi_term_atom_lte/demo_stokes_vs_B_lte_MnI.py
@@ -1,5 +1,3 @@
-import logging
-
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.common_api.constant_property_slab import ConstantPropertySlabAtmosphere
 from solrat.atom_model.shared.common_api.multi_slab_atmosphere import MultiSlabAtmosphere
@@ -14,7 +12,7 @@ def main():
     """
     Zeeman effect in the Mn I 5432 A line (LTE) for a range of magnetic field strengths.
     """
-    setup_logging(logging.INFO)
+    setup_logging()
 
     model = PreconfiguredModels.multi_term_atom_lte_MnI_5432()
     reference_lambda_A_air = model.config.reference_lambda_A_air

--- a/_demos/multi_term_atom_lte/demo_stokes_vs_B_lte_MnI.py
+++ b/_demos/multi_term_atom_lte/demo_stokes_vs_B_lte_MnI.py
@@ -1,0 +1,67 @@
+import logging
+
+import numpy as np
+from yatools import logging_config
+
+from solrat.atom_model.model_registry import PreconfiguredModels
+from solrat.atom_model.shared.common_api.constant_property_slab import ConstantPropertySlabAtmosphere
+from solrat.atom_model.shared.common_api.multi_slab_atmosphere import MultiSlabAtmosphere
+from solrat.atom_model.shared.object.angles import Angles
+from solrat.atom_model.shared.object.stokes import Stokes
+from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
+from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesNorm, StokesPlotter_IV_IpmV
+
+
+def main():
+    """
+    Zeeman effect in the Mn I 5432 A line (LTE) for a range of magnetic field strengths.
+    """
+    logging_config.init(logging.INFO)
+
+    model = PreconfiguredModels.multi_term_atom_lte_MnI_5432()
+
+    reference_lambda = model.config.reference_lambda_A
+    lambda_A = np.arange(reference_lambda - 0.6, reference_lambda + 0.6, 0.005)
+    nu = lambda_A_to_frequency_hz(lambda_A)
+
+    angles = Angles(chi=0, theta=0, gamma=0, chi_B=0, theta_B=0)
+
+    initial_stokes = Stokes.from_BP(nu_sm1=nu, temperature_K=5700)
+
+    plotter = StokesPlotter_IV_IpmV("Mn I 5432 — Zeeman effect (LTE)")
+
+    for B in [0, 500, 1000, 2000]:
+        atmosphere_parameters = model.AtmosphereParameters(
+            model_config=model.config,
+            magnetic_field_gauss=B,
+            temperature_K=5000,
+            delta_v_turbulent_cm_sm1=100_000,
+            macroscopic_velocity_cm_sm1=0,
+            voigt_a=0,
+        )
+        atmosphere = MultiSlabAtmosphere(
+            ConstantPropertySlabAtmosphere(
+                model=model,
+                radiation_tensor=model.RadiationTensor(),
+                line_delta_tau=0.3,
+                continuum_delta_tau=0.01,
+                angles=angles,
+                atmosphere_parameters=atmosphere_parameters,
+            )
+        )
+        stokes = atmosphere.forward(initial_stokes=initial_stokes)
+
+        plotter.add_stokes(
+            lambda_A=lambda_A,
+            lambda_ref_A=reference_lambda,
+            stokes=stokes,
+            norm=StokesNorm.BY_REFERENCE,
+            stokes_reference=initial_stokes,
+            label=f"B = {B} G",
+        )
+
+    plotter.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/_demos/start_here/demo_basic_stokes_profile_synthesis.py
+++ b/_demos/start_here/demo_basic_stokes_profile_synthesis.py
@@ -1,0 +1,109 @@
+import numpy as np
+
+from solrat.atom_model.model_registry import PreconfiguredModels
+from solrat.atom_model.shared.common_api.constant_property_slab import ConstantPropertySlabAtmosphere
+from solrat.atom_model.shared.common_api.multi_slab_atmosphere import MultiSlabAtmosphere
+from solrat.atom_model.shared.object.angles import Angles
+from solrat.atom_model.shared.object.stokes import Stokes
+from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range
+from solrat.atom_model.shared.utility.log_setup import setup_logging
+from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesPlotter
+
+
+def main():
+    """
+    This example demonstrates a minimal workflow for synthesizing the Stokes profiles of the He I D3 line
+    using a built-in pre-configured model through the public API.
+
+    To run this demo, SolRaT needs to be installed.
+    The easiest way is to install SolRaT using "pip install solrat" command.
+
+    You can also clone the repository and run _demos/start_here/demo_basic_stokes_profile_synthesis.py directly.
+    The latter is recommended if you plan to extend available models or creating your own.
+    """
+
+    # Set up the logger. Use setup_logging(logging.DEBUG) for a verbose logging
+    setup_logging()
+
+    # Get a built-in pre-configured model for the D3 transition
+    # You can browse PreconfiguredModels to see all available pre-configured transfer models.
+    # Additionally, you can configure a transfer model for your own atom.
+    # The latter can be easily done by direct analogy to pre-configured models.
+    model = PreconfiguredModels.multi_term_atom_HeID3()
+    reference_lambda_A_air = model.config.reference_lambda_A_air
+
+    # The calculation itself needs frequency, but we will display the results in air wavelength.
+    # Therefore, it is convenient to derive the frequencies from the wavelengths range of interest.
+    # Note that SolRaT scales gracefully with the number of frequency points,
+    # so feel free to request a high spectral resolution.
+    nu = get_frequencies_from_air_wavelength_range(
+        lower_wavelength_A=reference_lambda_A_air - 0.3,
+        upper_wavelength_A=reference_lambda_A_air + 0.6,
+        step_A=5e-3,
+    )
+
+    # Set up the observation geometry. See Fig. 5.9 in LL04 for reference
+    # In short:
+    # chi, theta, and gamma are the Euler angles for the Omega (LOS) vector.
+    # chi_B and theta_B are the Euler angles for the magnetic field B vector.
+    angles = Angles(
+        chi=0,
+        theta=np.pi / 4,
+        gamma=0,
+        chi_B=0,
+        theta_B=0,
+    )
+
+    # Define the atmosphere parameters
+    atmosphere_parameters = model.AtmosphereParameters(
+        model_config=model.config,
+        magnetic_field_gauss=1000,
+        temperature_K=5000,
+        delta_v_turbulent_cm_sm1=0,  # non-thermal temperature for additional Gaussian broadening
+        macroscopic_velocity_cm_sm1=0,  # Doppler shift, typically used when multiple emission components are modeled
+        voigt_a=0,  # Voigt damping coefficient
+    )
+
+    # Construct a radiation tensor from the built-in height-stratified parametrization
+    # Here we use NLTE J tensor for the height of 30 arcsec above photosphere.
+    # Another option is .fill_planck(self, temperature_K) - fill using LTE Planck distribution
+    radiation_tensor = model.RadiationTensor.from_model_config(model.config).fill_NLTE_n_w_parametrized(h_arcsec=30)
+
+    # Set up the initial Stokes vector: zero in this case, corresponding to a limb observation
+    # Another option is .from_BP(nu_sm1, temperature_K) - fill using LTE Planck distribution
+    initial_stokes = Stokes.from_zeros(nu_sm1=nu)
+
+    # Define the atmosphere. Here we use a MultiSlabAtmosphere with a single slab
+    atmosphere = MultiSlabAtmosphere(
+        ConstantPropertySlabAtmosphere(
+            model=model,
+            radiation_tensor=radiation_tensor,
+            line_delta_tau=0.1,  # optical depth of the slab in the line-center frequency
+            continuum_delta_tau=0.001,  # optical depth in the far continuum
+            angles=angles,
+            atmosphere_parameters=atmosphere_parameters,
+        ),
+        # Subsequent slabs can be added here
+    )
+
+    # Set up a plotter for easier visualization of results
+    plotter = StokesPlotter("Stokes profiles for the He I D3 line", reference_lambda_A_air=reference_lambda_A_air)
+
+    # Calculate the emerging Stokes profiles and add them to the plot
+    emerging_stokes = atmosphere.forward(initial_stokes=initial_stokes)
+
+    # Plot the emerging Stokes profiles
+    plotter.add_stokes(
+        nu=nu,
+        stokes=emerging_stokes,
+        norm=plotter.Norm.MAX_I,  # Normalize using maximum I intensity. Other options: BY_REFERENCE, MAX_IpV_ImV, NONE
+        # stokes_reference=initial_stokes # for on-disk observations, used when norm is BY_REFERENCE.
+        label="$B=1000$ G",
+    )
+
+    # Show the plot
+    plotter.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/_tests/atom_model/multi_term_atom_model/object/test_level_registry.py
+++ b/_tests/atom_model/multi_term_atom_model/object/test_level_registry.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 
 from solrat.atom_model.multi_term_atom_model.object.level_registry import LevelRegistry
@@ -7,7 +6,7 @@ from solrat.atom_model.shared.utility.log_setup import setup_logging
 
 class TestLevelRegistry(unittest.TestCase):
     def test_level_registry(self):
-        setup_logging(logging.INFO)
+        setup_logging()
 
         level_registry = LevelRegistry()
         level_registry.register_level(

--- a/_tests/atom_model/multi_term_atom_model/object/test_level_registry.py
+++ b/_tests/atom_model/multi_term_atom_model/object/test_level_registry.py
@@ -1,14 +1,13 @@
 import logging
 import unittest
 
-from yatools import logging_config
-
 from solrat.atom_model.multi_term_atom_model.object.level_registry import LevelRegistry
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 
 
 class TestLevelRegistry(unittest.TestCase):
     def test_level_registry(self):
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         level_registry = LevelRegistry()
         level_registry.register_level(

--- a/_tests/atom_model/multi_term_atom_model/object/test_transition_registry.py
+++ b/_tests/atom_model/multi_term_atom_model/object/test_transition_registry.py
@@ -1,15 +1,14 @@
 import logging
 import unittest
 
-from yatools import logging_config
-
 from solrat.atom_model.multi_term_atom_model.object.level_registry import LevelRegistry
 from solrat.atom_model.multi_term_atom_model.object.transition_registry import TransitionRegistry
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 
 
 class TestTransitionRegistry(unittest.TestCase):
     def test_transition_registry(self):
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         level_registry = LevelRegistry()
         level_registry.register_level(

--- a/_tests/atom_model/multi_term_atom_model/object/test_transition_registry.py
+++ b/_tests/atom_model/multi_term_atom_model/object/test_transition_registry.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 
 from solrat.atom_model.multi_term_atom_model.object.level_registry import LevelRegistry
@@ -8,7 +7,7 @@ from solrat.atom_model.shared.utility.log_setup import setup_logging
 
 class TestTransitionRegistry(unittest.TestCase):
     def test_transition_registry(self):
-        setup_logging(logging.INFO)
+        setup_logging()
 
         level_registry = LevelRegistry()
         level_registry.register_level(

--- a/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_D3.py
+++ b/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_D3.py
@@ -2,25 +2,26 @@ import logging
 import unittest
 
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.utility.constants import atomic_mass_unit_g, kB_erg_Km1
-from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
+from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 from solrat.engine.functions.special import pseudo_hash
 
 
 class TestRadiativeTransferEquationsD3(unittest.TestCase):
     def test_radiative_transfer_equations_d3(self):
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         model = PreconfiguredModels.multi_term_atom_HeID3()
-        reference_lambda = model.config.reference_lambda_A
-
-        # The calculation itself needs frequency, but we will display the results in wavelength
-        lambda_A = np.arange(reference_lambda - 2, reference_lambda + 2, 5e-4)
-        nu = lambda_A_to_frequency_hz(lambda_A)
+        reference_lambda_A_air = model.config.reference_lambda_A_air
+        nu = get_frequencies_from_air_wavelength_range(
+            lower_wavelength_A=reference_lambda_A_air - 2,
+            upper_wavelength_A=reference_lambda_A_air + 2,
+            step_A=5e-4,
+        )
 
         angles = Angles(
             chi=np.pi / 5,
@@ -56,7 +57,7 @@ class TestRadiativeTransferEquationsD3(unittest.TestCase):
         eta_rho_sI, eta_rho_sQ, eta_rho_sU, eta_rho_sV = eta_rho_s[0], eta_rho_s[1], eta_rho_s[2], eta_rho_s[3]
 
         # Check that the result did not change from previous runs
-        last_run_hash = 2.3137071959665785e-16
+        last_run_hash = 2.312804517792012e-16
         new_hash = pseudo_hash(eta_rho_sI, eta_rho_sQ, eta_rho_sU, eta_rho_sV)
         logging.info(new_hash)
         logging.info(last_run_hash)

--- a/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_D3.py
+++ b/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_D3.py
@@ -52,18 +52,8 @@ class TestRadiativeTransferEquationsD3(unittest.TestCase):
         rho = see.get_solution()
 
         # get RT coefficients. They are complex: eta = real(eta_rho), rho = imag(eta_rho)
-        eta_rho_sI = rte.calculate_eta_rho_s(
-            stokes_component_index=0, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
-        eta_rho_sQ = rte.calculate_eta_rho_s(
-            stokes_component_index=1, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
-        eta_rho_sU = rte.calculate_eta_rho_s(
-            stokes_component_index=2, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
-        eta_rho_sV = rte.calculate_eta_rho_s(
-            stokes_component_index=3, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
+        eta_rho_s = rte.calculate_eta_rho_s(rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles)
+        eta_rho_sI, eta_rho_sQ, eta_rho_sU, eta_rho_sV = eta_rho_s[0], eta_rho_s[1], eta_rho_s[2], eta_rho_s[3]
 
         # Check that the result did not change from previous runs
         last_run_hash = 2.3137071959665785e-16

--- a/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_D3.py
+++ b/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_D3.py
@@ -13,7 +13,7 @@ from solrat.engine.functions.special import pseudo_hash
 
 class TestRadiativeTransferEquationsD3(unittest.TestCase):
     def test_radiative_transfer_equations_d3(self):
-        setup_logging(logging.INFO)
+        setup_logging()
 
         model = PreconfiguredModels.multi_term_atom_HeID3()
         reference_lambda_A_air = model.config.reference_lambda_A_air

--- a/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_resonance.py
+++ b/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_resonance.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 
 import numpy as np
@@ -12,7 +11,7 @@ from solrat.atom_model.shared.utility.log_setup import setup_logging
 class TestRadiativeTransferEquationsResonance(unittest.TestCase):
     def test_radiative_transfer_equations_resonance(self):
         # (10.127)
-        setup_logging(logging.INFO)
+        setup_logging()
 
         model = PreconfiguredModels.multi_term_atom_mock()
         reference_lambda_A_air = model.config.reference_lambda_A_air

--- a/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_resonance.py
+++ b/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_resonance.py
@@ -79,18 +79,8 @@ class TestRadiativeTransferEquationsResonance(unittest.TestCase):
         assert np.allclose(rtc.get_epsilon_U(), rtc_legacy.get_epsilon_U(), atol=1e-10, rtol=1e-10)
         assert np.allclose(rtc.get_epsilon_V(), rtc_legacy.get_epsilon_V(), atol=1e-10, rtol=1e-10)
 
-        eta_aI = rte.calculate_eta_rho_a(
-            stokes_component_index=0, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
-        eta_aQ = rte.calculate_eta_rho_a(
-            stokes_component_index=1, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
-        eta_aU = rte.calculate_eta_rho_a(
-            stokes_component_index=2, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
-        eta_aV = rte.calculate_eta_rho_a(
-            stokes_component_index=3, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
+        eta_a = rte.calculate_eta_rho_a(rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles)
+        eta_aI, eta_aQ, eta_aU, eta_aV = eta_a[0], eta_a[1], eta_a[2], eta_a[3]
 
         eta_aI_legacy = rte_legacy.eta_rho_a(
             rho=rho_legacy, stokes_component_index=0, atmosphere_parameters=atmosphere_parameters, angles=angles
@@ -122,18 +112,8 @@ class TestRadiativeTransferEquationsResonance(unittest.TestCase):
         )
         assert np.allclose(eta_aV / scale, eta_aV_legacy / scale, atol=1e-10, rtol=1e-10)
 
-        eta_sI = rte.calculate_eta_rho_s(
-            stokes_component_index=0, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
-        eta_sQ = rte.calculate_eta_rho_s(
-            stokes_component_index=1, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
-        eta_sU = rte.calculate_eta_rho_s(
-            stokes_component_index=2, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
-        eta_sV = rte.calculate_eta_rho_s(
-            stokes_component_index=3, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
+        eta_s = rte.calculate_eta_rho_s(rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles)
+        eta_sI, eta_sQ, eta_sU, eta_sV = eta_s[0], eta_s[1], eta_s[2], eta_s[3]
 
         eta_sI_legacy = rte_legacy.eta_rho_s(
             rho=rho_legacy, stokes_component_index=0, atmosphere_parameters=atmosphere_parameters, angles=angles
@@ -181,5 +161,5 @@ class TestRadiativeTransferEquationsResonance(unittest.TestCase):
         assert np.allclose(np.real(eta_sV) / scale, eta_sV_analytic / scale, atol=1e-10, rtol=1e-10)
 
         epsilonI_legacy = rte_legacy.epsilon(eta_s=eta_sI_legacy, nu=nu)
-        epsilonI = rte.compute_epsilon(eta_s=eta_sI, nu=nu)
+        epsilonI = rte.calculate_epsilon(eta_s=eta_sI, nu=nu)
         assert np.allclose(epsilonI_legacy, epsilonI, atol=1e-10, rtol=1e-10)

--- a/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_resonance.py
+++ b/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_resonance.py
@@ -2,22 +2,25 @@ import logging
 import unittest
 
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.object.angles import Angles
-from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
+from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 
 
 class TestRadiativeTransferEquationsResonance(unittest.TestCase):
     def test_radiative_transfer_equations_resonance(self):
         # (10.127)
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         model = PreconfiguredModels.multi_term_atom_mock()
-        reference_nu = lambda_A_to_frequency_hz(model.config.reference_lambda_A)
-
-        nu = np.arange(reference_nu - 1e11, reference_nu + 1e11, 1e8)  # Hz
+        reference_lambda_A_air = model.config.reference_lambda_A_air
+        nu = get_frequencies_from_air_wavelength_range(
+            lower_wavelength_A=reference_lambda_A_air - 1,
+            upper_wavelength_A=reference_lambda_A_air + 1,
+            step_A=5e-4,
+        )
 
         angles = Angles(
             chi=np.pi / 5,
@@ -30,7 +33,7 @@ class TestRadiativeTransferEquationsResonance(unittest.TestCase):
         see = model.StatisticalEquilibriumEquations.from_model_config(model.config)
         rte = model.RadiativeTransferEquations.from_model_config(model.config, nu=nu)
 
-        radiation_tensor = model.RadiationTensor.from_model_config(model.config).fill_planck(T_K=5000)
+        radiation_tensor = model.RadiationTensor.from_model_config(model.config).fill_planck(temperature_K=5000)
 
         atmosphere_parameters = model.AtmosphereParameters(
             model_config=model.config,

--- a/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_resonance_nofs.py
+++ b/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_resonance_nofs.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 
 import numpy as np
@@ -12,7 +11,7 @@ from solrat.atom_model.shared.utility.log_setup import setup_logging
 class TestRadiativeTransferEquationsResonanceNoFS(unittest.TestCase):
     def test_radiative_transfer_equations_resonance_nofs(self):
         # (10.127)
-        setup_logging(logging.INFO)
+        setup_logging()
 
         model = PreconfiguredModels.multi_term_atom_mock_nofs()
         reference_lambda_A_air = model.config.reference_lambda_A_air

--- a/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_resonance_nofs.py
+++ b/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_resonance_nofs.py
@@ -2,22 +2,25 @@ import logging
 import unittest
 
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.object.angles import Angles
-from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
+from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 
 
 class TestRadiativeTransferEquationsResonanceNoFS(unittest.TestCase):
     def test_radiative_transfer_equations_resonance_nofs(self):
         # (10.127)
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         model = PreconfiguredModels.multi_term_atom_mock_nofs()
-        reference_nu = lambda_A_to_frequency_hz(model.config.reference_lambda_A)
-
-        nu = np.arange(reference_nu - 1e11, reference_nu + 1e11, 1e8)  # Hz
+        reference_lambda_A_air = model.config.reference_lambda_A_air
+        nu = get_frequencies_from_air_wavelength_range(
+            lower_wavelength_A=reference_lambda_A_air - 1,
+            upper_wavelength_A=reference_lambda_A_air + 1,
+            step_A=5e-4,
+        )
 
         angles = Angles(
             chi=np.pi / 5,
@@ -30,7 +33,7 @@ class TestRadiativeTransferEquationsResonanceNoFS(unittest.TestCase):
         see = model.StatisticalEquilibriumEquations.from_model_config(model.config)
         rte = model.RadiativeTransferEquations.from_model_config(model.config, nu=nu)
 
-        radiation_tensor = model.RadiationTensor.from_model_config(model.config).fill_planck(T_K=5000)
+        radiation_tensor = model.RadiationTensor.from_model_config(model.config).fill_planck(temperature_K=5000)
 
         atmosphere_parameters = model.AtmosphereParameters(
             model_config=model.config,

--- a/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_resonance_nofs.py
+++ b/_tests/atom_model/multi_term_atom_model/test_radiative_transfer_equations_resonance_nofs.py
@@ -55,18 +55,8 @@ class TestRadiativeTransferEquationsResonanceNoFS(unittest.TestCase):
         rho_legacy = see_legacy.get_solution()
         rte_legacy = model_legacy.RadiativeTransferEquations.from_model_config(model.config, nu=nu)
 
-        eta_aI = rte.calculate_eta_rho_a(
-            stokes_component_index=0, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
-        eta_aQ = rte.calculate_eta_rho_a(
-            stokes_component_index=1, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
-        eta_aU = rte.calculate_eta_rho_a(
-            stokes_component_index=2, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
-        eta_aV = rte.calculate_eta_rho_a(
-            stokes_component_index=3, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
+        eta_a = rte.calculate_eta_rho_a(rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles)
+        eta_aI, eta_aQ, eta_aU, eta_aV = eta_a[0], eta_a[1], eta_a[2], eta_a[3]
         eta_aI_legacy = rte_legacy.eta_rho_a(
             rho=rho_legacy,
             stokes_component_index=0,
@@ -156,18 +146,8 @@ class TestRadiativeTransferEquationsResonanceNoFS(unittest.TestCase):
         assert np.allclose(np.real(eta_aV) / scale, eta_aV_analytic / scale, atol=1e-10, rtol=1e-10)
         assert np.allclose(np.imag(eta_aV) / scale, rho_aV_analytic / scale, atol=1e-10, rtol=1e-10)
 
-        eta_sI = rte.calculate_eta_rho_s(
-            stokes_component_index=0, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
-        eta_sQ = rte.calculate_eta_rho_s(
-            stokes_component_index=1, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
-        eta_sU = rte.calculate_eta_rho_s(
-            stokes_component_index=2, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
-        eta_sV = rte.calculate_eta_rho_s(
-            stokes_component_index=3, rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles
-        )
+        eta_s = rte.calculate_eta_rho_s(rho=rho, atmosphere_parameters=atmosphere_parameters, angles=angles)
+        eta_sI, eta_sQ, eta_sU, eta_sV = eta_s[0], eta_s[1], eta_s[2], eta_s[3]
 
         eta_sI_legacy = rte_legacy.eta_rho_s(
             rho=rho_legacy,

--- a/_tests/atom_model/multi_term_atom_model/test_see_precomputation_reproducible.py
+++ b/_tests/atom_model/multi_term_atom_model/test_see_precomputation_reproducible.py
@@ -2,12 +2,12 @@ import logging
 import unittest
 
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.multi_term_atom_model.object.multi_term_atom_config import MultiTermAtomConfig
 from solrat.atom_model.multi_term_atom_model.object.precomputed_data import PrecomputedData
 from solrat.atom_model.shared.object.angles import Angles
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 from solrat.engine.functions.looping import PROJECTION, TRIANGULAR
 from solrat.engine.generators.nested_loops import nested_loops
 
@@ -19,7 +19,7 @@ class TestSEEPrecomputationReproducible(unittest.TestCase):
     """
 
     def test_precomputation_roundtrip(self):
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         model = PreconfiguredModels.multi_term_atom_mock()
 
@@ -39,7 +39,7 @@ class TestSEEPrecomputationReproducible(unittest.TestCase):
             level_registry=model.config.level_registry,
             transition_registry=model.config.transition_registry,
             atomic_mass_amu=model.config.atomic_mass_amu,
-            reference_lambda_A=model.config.reference_lambda_A,
+            reference_lambda_A_air=model.config.reference_lambda_A_air,
             precomputed_data=precomputed,
         )
 

--- a/_tests/atom_model/multi_term_atom_model/test_see_precomputation_reproducible.py
+++ b/_tests/atom_model/multi_term_atom_model/test_see_precomputation_reproducible.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 
 import numpy as np
@@ -19,7 +18,7 @@ class TestSEEPrecomputationReproducible(unittest.TestCase):
     """
 
     def test_precomputation_roundtrip(self):
-        setup_logging(logging.INFO)
+        setup_logging()
 
         model = PreconfiguredModels.multi_term_atom_mock()
 

--- a/_tests/atom_model/multi_term_atom_model/test_see_precomputation_reproducible.py
+++ b/_tests/atom_model/multi_term_atom_model/test_see_precomputation_reproducible.py
@@ -1,0 +1,90 @@
+import logging
+import unittest
+
+import numpy as np
+from yatools import logging_config
+
+from solrat.atom_model.model_registry import PreconfiguredModels
+from solrat.atom_model.multi_term_atom_model.object.multi_term_atom_config import MultiTermAtomConfig
+from solrat.atom_model.multi_term_atom_model.object.precomputed_data import PrecomputedData
+from solrat.atom_model.shared.object.angles import Angles
+from solrat.engine.functions.looping import PROJECTION, TRIANGULAR
+from solrat.engine.generators.nested_loops import nested_loops
+
+
+class TestSEEPrecomputationReproducible(unittest.TestCase):
+    """
+    Verify that precomputed frames extracted from a fresh SEE can be injected into
+    a new config and produce an identical rho solution.
+    """
+
+    def test_precomputation_roundtrip(self):
+        logging_config.init(logging.INFO)
+
+        model = PreconfiguredModels.multi_term_atom_mock()
+
+        see_original = model.StatisticalEquilibriumEquations.from_model_config(model.config)
+
+        precomputed = PrecomputedData(
+            coherence_decay_df=see_original.coherence_decay_df,
+            absorption_df=see_original.absorption_df,
+            emission_df_e=see_original.emission_df_e,
+            emission_df_s=see_original.emission_df_s,
+            relaxation_df_a=see_original.relaxation_df_a,
+            relaxation_df_e=see_original.relaxation_df_e,
+            relaxation_df_s=see_original.relaxation_df_s,
+        )
+
+        config_cached = MultiTermAtomConfig(
+            level_registry=model.config.level_registry,
+            transition_registry=model.config.transition_registry,
+            atomic_mass_amu=model.config.atomic_mass_amu,
+            reference_lambda_A=model.config.reference_lambda_A,
+            precomputed_data=precomputed,
+        )
+
+        see_cached = model.StatisticalEquilibriumEquations.from_model_config(config_cached)
+
+        angles = Angles(
+            chi=np.pi / 5,
+            theta=np.pi / 7,
+            gamma=np.pi / 9,
+            chi_B=np.pi / 3,
+            theta_B=np.pi / 5,
+        )
+        atmosphere_parameters = model.AtmosphereParameters(
+            model_config=model.config,
+            magnetic_field_gauss=100,
+            temperature_K=7000,
+        )
+        radiation_tensor_mag = (
+            model.RadiationTensor.from_model_config(model.config)
+            .fill_NLTE_n_w_parametrized(h_arcsec=30)
+            .rotate_to_magnetic_frame(angles=angles)
+        )
+
+        see_original.fill_all_equations(
+            atmosphere_parameters=atmosphere_parameters,
+            radiation_tensor_in_magnetic_frame=radiation_tensor_mag,
+        )
+        see_cached.fill_all_equations(
+            atmosphere_parameters=atmosphere_parameters,
+            radiation_tensor_in_magnetic_frame=radiation_tensor_mag,
+        )
+
+        rho = see_original.get_solution()
+        rho_cached = see_cached.get_solution()
+
+        for term in model.config.level_registry.terms.values():
+            for J, Jʹ, K, Q in nested_loops(
+                J=TRIANGULAR(term.L, term.S),
+                Jʹ=TRIANGULAR(term.L, term.S),
+                K=TRIANGULAR("J", "Jʹ"),
+                Q=PROJECTION("K"),
+            ):
+                a = rho(term_id=term.term_id, K=K, Q=Q, J=J, Jʹ=Jʹ)
+                b = rho_cached(term_id=term.term_id, K=K, Q=Q, J=J, Jʹ=Jʹ)
+                assert np.allclose(a, b, rtol=1e-10, atol=1e-10), (
+                    f"term={term.term_id} K={K} Q={Q} J={J} Jʹ={Jʹ}: "
+                    f"precompute roundtrip mismatch {np.abs(a - b).max():.2e}"
+                )

--- a/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations.py
+++ b/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations.py
@@ -3,17 +3,17 @@ import unittest
 
 import numpy as np
 from numpy import sqrt
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import Models
 from solrat.atom_model.multi_term_atom_model.object.level_registry import LevelRegistry
 from solrat.atom_model.multi_term_atom_model.object.transition_registry import TransitionRegistry
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 
 
 class TestStatisticalEquilibriumEquationsResonance(unittest.TestCase):
     def test_statistical_equilibrium_equations_resonance(self):
         # (10.126)
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         level_registry = LevelRegistry()
         level_registry.register_level(
@@ -51,7 +51,7 @@ class TestStatisticalEquilibriumEquationsResonance(unittest.TestCase):
                 level_registry=level_registry,
                 transition_registry=transition_registry,
                 atomic_mass_amu=4,
-                reference_lambda_A=np.nan,
+                reference_lambda_A_air=np.nan,
                 disable_r_s=True,
             )
         )
@@ -62,7 +62,7 @@ class TestStatisticalEquilibriumEquationsResonance(unittest.TestCase):
                 level_registry=level_registry,
                 transition_registry=transition_registry,
                 atomic_mass_amu=4,
-                reference_lambda_A=np.nan,
+                reference_lambda_A_air=np.nan,
                 disable_r_s=True,
             )
         )

--- a/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations.py
+++ b/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 
 import numpy as np
@@ -13,7 +12,7 @@ from solrat.atom_model.shared.utility.log_setup import setup_logging
 class TestStatisticalEquilibriumEquationsResonance(unittest.TestCase):
     def test_statistical_equilibrium_equations_resonance(self):
         # (10.126)
-        setup_logging(logging.INFO)
+        setup_logging()
 
         level_registry = LevelRegistry()
         level_registry.register_level(

--- a/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_disable_r_s.py
+++ b/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_disable_r_s.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 
 import numpy as np
@@ -55,7 +54,7 @@ class TestStatisticalEquilibriumEquationsDisableRs(unittest.TestCase):
         return see.get_solution(), see_legacy.get_solution()
 
     def test_disable_r_s(self):
-        setup_logging(logging.INFO)
+        setup_logging()
 
         base_model = PreconfiguredModels.multi_term_atom_mock()
         base_legacy = PreconfiguredModels.multi_term_atom_legacy_mock()

--- a/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_disable_r_s.py
+++ b/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_disable_r_s.py
@@ -2,10 +2,10 @@ import logging
 import unittest
 
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import Models, PreconfiguredModels
 from solrat.atom_model.shared.object.angles import Angles
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 from solrat.engine.functions.looping import PROJECTION, TRIANGULAR
 from solrat.engine.generators.nested_loops import nested_loops
 
@@ -25,7 +25,7 @@ class TestStatisticalEquilibriumEquationsDisableRs(unittest.TestCase):
                 level_registry=cfg.level_registry,
                 transition_registry=cfg.transition_registry,
                 atomic_mass_amu=cfg.atomic_mass_amu,
-                reference_lambda_A=cfg.reference_lambda_A,
+                reference_lambda_A_air=cfg.reference_lambda_A_air,
                 disable_r_s=disable_r_s,
             )
         )
@@ -34,7 +34,7 @@ class TestStatisticalEquilibriumEquationsDisableRs(unittest.TestCase):
                 level_registry=cfg.level_registry,
                 transition_registry=cfg.transition_registry,
                 atomic_mass_amu=cfg.atomic_mass_amu,
-                reference_lambda_A=cfg.reference_lambda_A,
+                reference_lambda_A_air=cfg.reference_lambda_A_air,
                 disable_r_s=disable_r_s,
             )
         )
@@ -55,7 +55,7 @@ class TestStatisticalEquilibriumEquationsDisableRs(unittest.TestCase):
         return see.get_solution(), see_legacy.get_solution()
 
     def test_disable_r_s(self):
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         base_model = PreconfiguredModels.multi_term_atom_mock()
         base_legacy = PreconfiguredModels.multi_term_atom_legacy_mock()

--- a/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_disable_r_s.py
+++ b/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_disable_r_s.py
@@ -1,0 +1,126 @@
+import logging
+import unittest
+
+import numpy as np
+from yatools import logging_config
+
+from solrat.atom_model.model_registry import Models, PreconfiguredModels
+from solrat.atom_model.shared.object.angles import Angles
+from solrat.engine.functions.looping import PROJECTION, TRIANGULAR
+from solrat.engine.generators.nested_loops import nested_loops
+
+
+class TestStatisticalEquilibriumEquationsDisableRs(unittest.TestCase):
+    """
+    Verify the disable_r_s flag: current and legacy SEE must agree for both
+    settings, and the two settings must produce physically different solutions.
+    """
+
+    def _build_model_pair(self, base_model, base_legacy_model, disable_r_s: bool):
+        """Clone the mock atom config with the requested disable_r_s setting."""
+        cfg = base_model.config
+
+        model = Models.multi_term_atom().configure(
+            config=base_model.Config(
+                level_registry=cfg.level_registry,
+                transition_registry=cfg.transition_registry,
+                atomic_mass_amu=cfg.atomic_mass_amu,
+                reference_lambda_A=cfg.reference_lambda_A,
+                disable_r_s=disable_r_s,
+            )
+        )
+        model_legacy = Models.multi_term_atom_legacy().configure(
+            config=base_legacy_model.Config(
+                level_registry=cfg.level_registry,
+                transition_registry=cfg.transition_registry,
+                atomic_mass_amu=cfg.atomic_mass_amu,
+                reference_lambda_A=cfg.reference_lambda_A,
+                disable_r_s=disable_r_s,
+            )
+        )
+        return model, model_legacy
+
+    def _solve_both(self, model, model_legacy, atmosphere_parameters, radiation_tensor_mag):
+        see = model.StatisticalEquilibriumEquations.from_model_config(model.config)
+        see_legacy = model_legacy.StatisticalEquilibriumEquations.from_model_config(model_legacy.config)
+
+        see.fill_all_equations(
+            atmosphere_parameters=atmosphere_parameters,
+            radiation_tensor_in_magnetic_frame=radiation_tensor_mag,
+        )
+        see_legacy.fill_all_equations(
+            atmosphere_parameters=atmosphere_parameters,
+            radiation_tensor_in_magnetic_frame=radiation_tensor_mag,
+        )
+        return see.get_solution(), see_legacy.get_solution()
+
+    def test_disable_r_s(self):
+        logging_config.init(logging.INFO)
+
+        base_model = PreconfiguredModels.multi_term_atom_mock()
+        base_legacy = PreconfiguredModels.multi_term_atom_legacy_mock()
+
+        angles = Angles(
+            chi=np.pi / 5,
+            theta=np.pi / 7,
+            gamma=np.pi / 9,
+            chi_B=np.pi / 3,
+            theta_B=np.pi / 5,
+        )
+        radiation_tensor = base_model.RadiationTensor.from_model_config(base_model.config).fill_NLTE_n_w_parametrized(
+            h_arcsec=30
+        )
+        radiation_tensor_mag = radiation_tensor.rotate_to_magnetic_frame(angles=angles)
+
+        atmosphere_parameters = base_model.AtmosphereParameters(
+            model_config=base_model.config,
+            magnetic_field_gauss=0,
+            temperature_K=7000,
+        )
+
+        # --- Case 1: stimulated emission enabled ---
+        model_on, model_legacy_on = self._build_model_pair(base_model, base_legacy, disable_r_s=False)
+        rho_on, rho_legacy_on = self._solve_both(model_on, model_legacy_on, atmosphere_parameters, radiation_tensor_mag)
+
+        # --- Case 2: stimulated emission disabled ---
+        model_off, model_legacy_off = self._build_model_pair(base_model, base_legacy, disable_r_s=True)
+        rho_off, rho_legacy_off = self._solve_both(
+            model_off, model_legacy_off, atmosphere_parameters, radiation_tensor_mag
+        )
+
+        terms = base_model.config.level_registry.terms.values()
+
+        # Current and legacy must agree for each setting
+        for term in terms:
+            for J, Jʹ, K, Q in nested_loops(
+                J=TRIANGULAR(term.L, term.S),
+                Jʹ=TRIANGULAR(term.L, term.S),
+                K=TRIANGULAR("J", "Jʹ"),
+                Q=PROJECTION("K"),
+            ):
+                kwargs = dict(term_id=term.term_id, K=K, Q=Q, J=J, Jʹ=Jʹ)
+                assert np.allclose(
+                    rho_on(**kwargs), rho_legacy_on(**kwargs), rtol=1e-10, atol=1e-10
+                ), "current vs legacy mismatch with disable_r_s=False"
+                assert np.allclose(
+                    rho_off(**kwargs), rho_legacy_off(**kwargs), rtol=1e-10, atol=1e-10
+                ), "current vs legacy mismatch with disable_r_s=True"
+
+        # The two settings must produce a physically different result
+        max_diff = 0.0
+        for term in terms:
+            for J, Jʹ, K, Q in nested_loops(
+                J=TRIANGULAR(term.L, term.S),
+                Jʹ=TRIANGULAR(term.L, term.S),
+                K=TRIANGULAR("J", "Jʹ"),
+                Q=PROJECTION("K"),
+            ):
+                kwargs = dict(term_id=term.term_id, K=K, Q=Q, J=J, Jʹ=Jʹ)
+                diff = np.abs(rho_on(**kwargs) - rho_off(**kwargs)).max()
+                if diff > max_diff:
+                    max_diff = diff
+
+        assert max_diff > 1e-6, (
+            f"disable_r_s=True/False produced nearly identical solutions (max diff {max_diff:.2e}); "
+            "stimulated emission appears to have no effect"
+        )

--- a/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_nonzero_B.py
+++ b/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_nonzero_B.py
@@ -1,0 +1,104 @@
+import logging
+import unittest
+
+import numpy as np
+from yatools import logging_config
+
+from solrat.atom_model.model_registry import PreconfiguredModels
+from solrat.atom_model.shared.object.angles import Angles
+from solrat.engine.functions.looping import PROJECTION, TRIANGULAR
+from solrat.engine.generators.nested_loops import nested_loops
+
+
+class TestStatisticalEquilibriumEquationsNonzeroB(unittest.TestCase):
+    """
+    Verify that the current and legacy SEE implementations agree at non-zero
+    magnetic field, exercising the Larmor precession path in the coherence-decay
+    kernel.
+    """
+
+    def _run_for_model_pair(self, model, model_legacy, magnetic_field_gauss, angles, radiation_tensor):
+        atmosphere_parameters = model.AtmosphereParameters(
+            model_config=model.config,
+            magnetic_field_gauss=magnetic_field_gauss,
+            temperature_K=7000,
+        )
+
+        see = model.StatisticalEquilibriumEquations.from_model_config(model.config)
+        see_legacy = model_legacy.StatisticalEquilibriumEquations.from_model_config(model_legacy.config)
+
+        radiation_tensor_mag = radiation_tensor.rotate_to_magnetic_frame(angles=angles)
+
+        see.fill_all_equations(
+            atmosphere_parameters=atmosphere_parameters,
+            radiation_tensor_in_magnetic_frame=radiation_tensor_mag,
+        )
+        see_legacy.fill_all_equations(
+            atmosphere_parameters=atmosphere_parameters,
+            radiation_tensor_in_magnetic_frame=radiation_tensor_mag,
+        )
+
+        rho = see.get_solution()
+        rho_legacy = see_legacy.get_solution()
+
+        for term in model.config.level_registry.terms.values():
+            for J, Jʹ, K, Q in nested_loops(
+                J=TRIANGULAR(term.L, term.S),
+                Jʹ=TRIANGULAR(term.L, term.S),
+                K=TRIANGULAR("J", "Jʹ"),
+                Q=PROJECTION("K"),
+            ):
+                a = rho(term_id=term.term_id, K=K, Q=Q, J=J, Jʹ=Jʹ)
+                b = rho_legacy(term_id=term.term_id, K=K, Q=Q, J=J, Jʹ=Jʹ)
+                assert np.allclose(a, b, rtol=1e-10, atol=1e-8), (
+                    f"term={term.term_id} K={K} Q={Q} J={J} Jʹ={Jʹ}: "
+                    f"max diff {np.abs(a - b).max():.2e} exceeds tolerance"
+                )
+
+    def test_nonzero_B_mock(self):
+        """Mock atom (with fine structure), B = 100 G, anisotropic radiation."""
+        logging_config.init(logging.INFO)
+
+        model = PreconfiguredModels.multi_term_atom_mock()
+        model_legacy = PreconfiguredModels.multi_term_atom_legacy_mock()
+
+        angles = Angles(
+            chi=np.pi / 5,
+            theta=np.pi / 7,
+            gamma=np.pi / 9,
+            chi_B=np.pi / 3,
+            theta_B=np.pi / 5,
+        )
+        radiation_tensor = model.RadiationTensor.from_model_config(model.config).fill_NLTE_n_w_parametrized(h_arcsec=30)
+
+        self._run_for_model_pair(
+            model=model,
+            model_legacy=model_legacy,
+            magnetic_field_gauss=100,
+            angles=angles,
+            radiation_tensor=radiation_tensor,
+        )
+
+    def test_nonzero_B_mock_nofs(self):
+        """Mock atom (no fine structure), B = 50 G, anisotropic radiation."""
+        logging_config.init(logging.INFO)
+
+        model = PreconfiguredModels.multi_term_atom_mock_nofs()
+        model_legacy = PreconfiguredModels.multi_term_atom_legacy_mock_nofs()
+
+        angles = Angles(
+            chi=np.pi / 6,
+            theta=np.pi / 4,
+            gamma=0,
+            chi_B=0,
+            theta_B=np.pi / 3,
+        )
+        radiation_tensor = model.RadiationTensor.from_model_config(model.config).fill_NLTE_n_w_parametrized(h_arcsec=30)
+
+        self._run_for_model_pair(
+            model=model,
+            model_legacy=model_legacy,
+            magnetic_field_gauss=50,
+            angles=angles,
+            radiation_tensor=radiation_tensor,
+        )

--- a/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_nonzero_B.py
+++ b/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_nonzero_B.py
@@ -2,10 +2,10 @@ import logging
 import unittest
 
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.object.angles import Angles
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 from solrat.engine.functions.looping import PROJECTION, TRIANGULAR
 from solrat.engine.generators.nested_loops import nested_loops
 
@@ -57,7 +57,7 @@ class TestStatisticalEquilibriumEquationsNonzeroB(unittest.TestCase):
 
     def test_nonzero_B_mock(self):
         """Mock atom (with fine structure), B = 100 G, anisotropic radiation."""
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         model = PreconfiguredModels.multi_term_atom_mock()
         model_legacy = PreconfiguredModels.multi_term_atom_legacy_mock()
@@ -81,7 +81,7 @@ class TestStatisticalEquilibriumEquationsNonzeroB(unittest.TestCase):
 
     def test_nonzero_B_mock_nofs(self):
         """Mock atom (no fine structure), B = 50 G, anisotropic radiation."""
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         model = PreconfiguredModels.multi_term_atom_mock_nofs()
         model_legacy = PreconfiguredModels.multi_term_atom_legacy_mock_nofs()

--- a/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_nonzero_B.py
+++ b/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_nonzero_B.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 
 import numpy as np
@@ -57,7 +56,7 @@ class TestStatisticalEquilibriumEquationsNonzeroB(unittest.TestCase):
 
     def test_nonzero_B_mock(self):
         """Mock atom (with fine structure), B = 100 G, anisotropic radiation."""
-        setup_logging(logging.INFO)
+        setup_logging()
 
         model = PreconfiguredModels.multi_term_atom_mock()
         model_legacy = PreconfiguredModels.multi_term_atom_legacy_mock()
@@ -81,7 +80,7 @@ class TestStatisticalEquilibriumEquationsNonzeroB(unittest.TestCase):
 
     def test_nonzero_B_mock_nofs(self):
         """Mock atom (no fine structure), B = 50 G, anisotropic radiation."""
-        setup_logging(logging.INFO)
+        setup_logging()
 
         model = PreconfiguredModels.multi_term_atom_mock_nofs()
         model_legacy = PreconfiguredModels.multi_term_atom_legacy_mock_nofs()

--- a/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_with_stimulated_emission.py
+++ b/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_with_stimulated_emission.py
@@ -2,16 +2,16 @@ import logging
 import unittest
 
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import PreconfiguredModels
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 from solrat.engine.functions.looping import PROJECTION, TRIANGULAR
 from solrat.engine.generators.nested_loops import nested_loops
 
 
 class TestStatisticalEquilibriumEquationsResonanceStimulated(unittest.TestCase):
     def test_statistical_equilibrium_equations_resonance_stimulated(self):
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         model = PreconfiguredModels.multi_term_atom_mock()
         model_legacy = PreconfiguredModels.multi_term_atom_legacy_mock()

--- a/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_with_stimulated_emission.py
+++ b/_tests/atom_model/multi_term_atom_model/test_statistical_equilibrium_equations_with_stimulated_emission.py
@@ -11,7 +11,7 @@ from solrat.engine.generators.nested_loops import nested_loops
 
 class TestStatisticalEquilibriumEquationsResonanceStimulated(unittest.TestCase):
     def test_statistical_equilibrium_equations_resonance_stimulated(self):
-        setup_logging(logging.INFO)
+        setup_logging()
 
         model = PreconfiguredModels.multi_term_atom_mock()
         model_legacy = PreconfiguredModels.multi_term_atom_legacy_mock()

--- a/_tests/atom_model/multi_term_atom_model_lte/test_statistical_equilibrium_equations_LTE.py
+++ b/_tests/atom_model/multi_term_atom_model_lte/test_statistical_equilibrium_equations_LTE.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 
 import numpy as np
@@ -12,7 +11,7 @@ from solrat.atom_model.shared.utility.log_setup import setup_logging
 class TestStatisticalEquilibriumEquationsLTE(unittest.TestCase):
     def test_statistical_equilibrium_equations_lte(self):
         # (10.126)
-        setup_logging(logging.INFO)
+        setup_logging()
 
         model = PreconfiguredModels.multi_term_atom_mock_nofs()
 

--- a/_tests/atom_model/multi_term_atom_model_lte/test_statistical_equilibrium_equations_LTE.py
+++ b/_tests/atom_model/multi_term_atom_model_lte/test_statistical_equilibrium_equations_LTE.py
@@ -2,17 +2,17 @@ import logging
 import unittest
 
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.utility.constants import h_erg_s, kB_erg_Km1, sqrt2
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 
 
 class TestStatisticalEquilibriumEquationsLTE(unittest.TestCase):
     def test_statistical_equilibrium_equations_lte(self):
         # (10.126)
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         model = PreconfiguredModels.multi_term_atom_mock_nofs()
 
@@ -31,7 +31,7 @@ class TestStatisticalEquilibriumEquationsLTE(unittest.TestCase):
         )
         radiation_tensor = (
             model.RadiationTensor.from_model_config(config=model.config)
-            .fill_planck(T_K=atmosphere_parameters.temperature_K)
+            .fill_planck(temperature_K=atmosphere_parameters.temperature_K)
             .rotate_to_magnetic_frame(angles=angles)
         )
 

--- a/_tests/atom_model/multi_term_atom_model_lte/test_statistical_equilibrium_equations_lte_real_atoms.py
+++ b/_tests/atom_model/multi_term_atom_model_lte/test_statistical_equilibrium_equations_lte_real_atoms.py
@@ -3,11 +3,11 @@ import unittest
 
 import numpy as np
 from numpy import sqrt
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.utility.constants import kB_erg_Km1
 from solrat.atom_model.shared.utility.functions import energy_cmm1_to_erg
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 
 
 class TestStatisticalEquilibriumEquationsLTERealAtoms(unittest.TestCase):
@@ -94,7 +94,7 @@ class TestStatisticalEquilibriumEquationsLTERealAtoms(unittest.TestCase):
         return excited_pop
 
     def test_lte_FeI_5434(self):
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
         model = PreconfiguredModels.multi_term_atom_lte_FeI_5434()
         self._run_checks(model)
 
@@ -103,7 +103,7 @@ class TestStatisticalEquilibriumEquationsLTERealAtoms(unittest.TestCase):
         assert frac_high > frac_low, "Excited fraction should increase with temperature"
 
     def test_lte_NiI_5435(self):
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
         model = PreconfiguredModels.multi_term_atom_lte_NiI_5435()
         self._run_checks(model)
 

--- a/_tests/atom_model/multi_term_atom_model_lte/test_statistical_equilibrium_equations_lte_real_atoms.py
+++ b/_tests/atom_model/multi_term_atom_model_lte/test_statistical_equilibrium_equations_lte_real_atoms.py
@@ -1,0 +1,112 @@
+import logging
+import unittest
+
+import numpy as np
+from numpy import sqrt
+from yatools import logging_config
+
+from solrat.atom_model.model_registry import PreconfiguredModels
+from solrat.atom_model.shared.utility.constants import kB_erg_Km1
+from solrat.atom_model.shared.utility.functions import energy_cmm1_to_erg
+
+
+class TestStatisticalEquilibriumEquationsLTERealAtoms(unittest.TestCase):
+    """
+    Physics checks for the LTE SEE on real atomic data (Fe I 5434, Ni I 5435):
+    trace normalisation, zero K!=0 coherences, correct Boltzmann ratios, and
+    increasing excited fraction with temperature.
+    """
+
+    TEMPERATURE_K = 5000
+
+    def _run_checks(self, model):
+        atmosphere_parameters = model.AtmosphereParameters(
+            model_config=model.config,
+            magnetic_field_gauss=0,
+            temperature_K=self.TEMPERATURE_K,
+        )
+        radiation_tensor = model.RadiationTensor.from_model_config(model.config)
+
+        see = model.StatisticalEquilibriumEquations.from_model_config(model.config)
+        see.fill_all_equations(
+            atmosphere_parameters=atmosphere_parameters,
+            radiation_tensor_in_magnetic_frame=radiation_tensor,
+        )
+        rho = see.get_solution()
+
+        trace = 0.0
+        for term in model.config.level_registry.terms.values():
+            for level in term.levels:
+                J = level.J
+                trace += sqrt(2 * J + 1) * np.real(rho(term_id=term.term_id, K=0, Q=0, J=J, Jʹ=J))
+        assert np.isclose(trace, 1.0, rtol=1e-10, atol=1e-10), f"Trace = {trace}, expected 1.0"
+
+        for index, (term_id, K, Q, J, Jʹ) in see.matrix_builder.index_to_parameters.items():
+            if K != 0:
+                val = rho(term_id=term_id, K=K, Q=Q, J=J, Jʹ=Jʹ)
+                assert np.allclose(val, 0, rtol=1e-10, atol=1e-10), f"Expected 0 for K={K}, got {val}"
+
+        T = self.TEMPERATURE_K
+        for term in model.config.level_registry.terms.values():
+            levels = sorted(term.levels, key=lambda lv: lv.energy_cmm1)
+            for i in range(len(levels) - 1):
+                lv_low = levels[i]
+                lv_high = levels[i + 1]
+                J_low, J_high = lv_low.J, lv_high.J
+                delta_E_erg = energy_cmm1_to_erg(lv_high.energy_cmm1 - lv_low.energy_cmm1)
+
+                rho_low = np.real(rho(term_id=term.term_id, K=0, Q=0, J=J_low, Jʹ=J_low))
+                rho_high = np.real(rho(term_id=term.term_id, K=0, Q=0, J=J_high, Jʹ=J_high))
+
+                if rho_low == 0:
+                    continue
+
+                actual_ratio = rho_high / rho_low
+                expected_ratio = (sqrt(2 * J_high + 1) / sqrt(2 * J_low + 1)) * np.exp(-delta_E_erg / (kB_erg_Km1 * T))
+                assert np.isclose(actual_ratio, expected_ratio, rtol=1e-10, atol=1e-10), (
+                    f"term={term.term_id} J={J_low} to {J_high}: "
+                    f"ratio {actual_ratio:.8f} vs Boltzmann {expected_ratio:.8f}"
+                )
+
+        return rho
+
+    def _excited_fraction(self, model, temperature_K):
+        """Return fraction of population in excited terms."""
+        atmosphere_parameters = model.AtmosphereParameters(
+            model_config=model.config,
+            magnetic_field_gauss=0,
+            temperature_K=temperature_K,
+        )
+        radiation_tensor = model.RadiationTensor.from_model_config(model.config)
+        see = model.StatisticalEquilibriumEquations.from_model_config(model.config)
+        see.fill_all_equations(
+            atmosphere_parameters=atmosphere_parameters,
+            radiation_tensor_in_magnetic_frame=radiation_tensor,
+        )
+        rho = see.get_solution()
+
+        min_energy = min(lv.energy_cmm1 for term in model.config.level_registry.terms.values() for lv in term.levels)
+        excited_pop = 0.0
+        for term in model.config.level_registry.terms.values():
+            for level in term.levels:
+                if level.energy_cmm1 > min_energy:
+                    excited_pop += np.real(rho(term_id=term.term_id, K=0, Q=0, J=level.J, Jʹ=level.J))
+        return excited_pop
+
+    def test_lte_FeI_5434(self):
+        logging_config.init(logging.INFO)
+        model = PreconfiguredModels.multi_term_atom_lte_FeI_5434()
+        self._run_checks(model)
+
+        frac_low = self._excited_fraction(model, temperature_K=3000)
+        frac_high = self._excited_fraction(model, temperature_K=8000)
+        assert frac_high > frac_low, "Excited fraction should increase with temperature"
+
+    def test_lte_NiI_5435(self):
+        logging_config.init(logging.INFO)
+        model = PreconfiguredModels.multi_term_atom_lte_NiI_5435()
+        self._run_checks(model)
+
+        frac_low = self._excited_fraction(model, temperature_K=3000)
+        frac_high = self._excited_fraction(model, temperature_K=8000)
+        assert frac_high > frac_low, "Excited fraction should increase with temperature"

--- a/_tests/atom_model/multi_term_atom_model_lte/test_statistical_equilibrium_equations_lte_real_atoms.py
+++ b/_tests/atom_model/multi_term_atom_model_lte/test_statistical_equilibrium_equations_lte_real_atoms.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 
 import numpy as np
@@ -94,7 +93,7 @@ class TestStatisticalEquilibriumEquationsLTERealAtoms(unittest.TestCase):
         return excited_pop
 
     def test_lte_FeI_5434(self):
-        setup_logging(logging.INFO)
+        setup_logging()
         model = PreconfiguredModels.multi_term_atom_lte_FeI_5434()
         self._run_checks(model)
 
@@ -103,7 +102,7 @@ class TestStatisticalEquilibriumEquationsLTERealAtoms(unittest.TestCase):
         assert frac_high > frac_low, "Excited fraction should increase with temperature"
 
     def test_lte_NiI_5435(self):
-        setup_logging(logging.INFO)
+        setup_logging()
         model = PreconfiguredModels.multi_term_atom_lte_NiI_5435()
         self._run_checks(model)
 

--- a/_tests/atom_model/shared/common_api/test_constant_property_slab_MnI.py
+++ b/_tests/atom_model/shared/common_api/test_constant_property_slab_MnI.py
@@ -18,7 +18,7 @@ class TestConstantPropertySlab(unittest.TestCase):
         """
         Sanity checks for ConstantPropertySlab with Mn I LTE synthesis.
         """
-        setup_logging(logging.INFO)
+        setup_logging()
 
         model = PreconfiguredModels.multi_term_atom_lte_MnI_5432()
         reference_lambda_A_air = model.config.reference_lambda_A_air

--- a/_tests/atom_model/shared/common_api/test_constant_property_slab_MnI.py
+++ b/_tests/atom_model/shared/common_api/test_constant_property_slab_MnI.py
@@ -2,14 +2,15 @@ import logging
 import unittest
 
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.model_registry import PreconfiguredModels
 from solrat.atom_model.shared.common_api.constant_property_slab import ConstantPropertySlabAtmosphere
 from solrat.atom_model.shared.common_api.multi_slab_atmosphere import MultiSlabAtmosphere
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.object.stokes import Stokes
-from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
+from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range
+from solrat.atom_model.shared.utility.log_setup import setup_logging
+from solrat.engine.functions.special import pseudo_hash
 
 
 class TestConstantPropertySlab(unittest.TestCase):
@@ -17,13 +18,15 @@ class TestConstantPropertySlab(unittest.TestCase):
         """
         Sanity checks for ConstantPropertySlab with Mn I LTE synthesis.
         """
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         model = PreconfiguredModels.multi_term_atom_lte_MnI_5432()
-        reference_lambda = model.config.reference_lambda_A
-
-        lambda_A = np.arange(reference_lambda - 0.5, reference_lambda + 0.5, 1e-3)
-        nu = lambda_A_to_frequency_hz(lambda_A)
+        reference_lambda_A_air = model.config.reference_lambda_A_air
+        nu = get_frequencies_from_air_wavelength_range(
+            lower_wavelength_A=reference_lambda_A_air - 0.5,
+            upper_wavelength_A=reference_lambda_A_air + 0.5,
+            step_A=1e-3,
+        )
 
         angles = Angles(chi=0, theta=0, gamma=0, chi_B=0, theta_B=0)
 
@@ -53,12 +56,9 @@ class TestConstantPropertySlab(unittest.TestCase):
 
         stokes_Mn = atmosphere_Mn.forward(initial_stokes=initial_stokes)
 
-        assert np.all(np.isfinite(stokes_Mn.I))
-        assert np.all(np.isfinite(stokes_Mn.V))
-        # Absorption line: emergent I must dip below the background continuum
-        assert np.min(stokes_Mn.I) < np.min(initial_stokes.I)
-        # theta=0 (along B): no linear polarisation
-        assert np.allclose(stokes_Mn.Q, 0, atol=1e-20)
-        assert np.allclose(stokes_Mn.U, 0, atol=1e-20)
-        # B=1000 G along LOS: circular polarisation must be present
-        assert np.max(np.abs(stokes_Mn.V)) > 0
+        # Check that the result did not change from previous runs
+        last_run_hash = 4.016455999176536e-05
+        new_hash = pseudo_hash(stokes_Mn.I, stokes_Mn.Q, stokes_Mn.U, stokes_Mn.V)
+        logging.info(new_hash)
+        logging.info(last_run_hash)
+        assert np.abs((last_run_hash - new_hash) / last_run_hash) < 1e-8

--- a/_tests/atom_model/shared/common_api/test_constant_property_slab_MnI.py
+++ b/_tests/atom_model/shared/common_api/test_constant_property_slab_MnI.py
@@ -10,25 +10,23 @@ from solrat.atom_model.shared.common_api.multi_slab_atmosphere import MultiSlabA
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.object.stokes import Stokes
 from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
-from solrat.engine.functions.special import pseudo_hash
 
 
 class TestConstantPropertySlab(unittest.TestCase):
     def test_constant_property_slab(self):
         """
-        Demonstrate basic usage of ConstantPropertySlab for He I D3 line synthesis.
+        Sanity checks for ConstantPropertySlab with Mn I LTE synthesis.
         """
         logging_config.init(logging.INFO)
 
         model = PreconfiguredModels.multi_term_atom_lte_MnI_5432()
         reference_lambda = model.config.reference_lambda_A
 
-        lambda_A = np.arange(reference_lambda + 1.5 - 0.5, reference_lambda + 1.1 + 1, 1e-3)
+        lambda_A = np.arange(reference_lambda - 0.5, reference_lambda + 0.5, 1e-3)
         nu = lambda_A_to_frequency_hz(lambda_A)
 
         angles = Angles(chi=0, theta=0, gamma=0, chi_B=0, theta_B=0)
 
-        # Atmosphere parameters:
         atmosphere1 = {
             "magnetic_field_gauss": 1000,
             "temperature_K": 5000,
@@ -55,9 +53,12 @@ class TestConstantPropertySlab(unittest.TestCase):
 
         stokes_Mn = atmosphere_Mn.forward(initial_stokes=initial_stokes)
 
-        # Check that the result did not change from previous runs
-        last_run_hash = 8.085295570214492e-05
-        new_hash = pseudo_hash(stokes_Mn.I, stokes_Mn.Q, stokes_Mn.U, stokes_Mn.V)
-        logging.info(new_hash)
-        logging.info(last_run_hash)
-        assert np.abs((last_run_hash - new_hash) / last_run_hash) < 1e-8
+        assert np.all(np.isfinite(stokes_Mn.I))
+        assert np.all(np.isfinite(stokes_Mn.V))
+        # Absorption line: emergent I must dip below the background continuum
+        assert np.min(stokes_Mn.I) < np.min(initial_stokes.I)
+        # theta=0 (along B): no linear polarisation
+        assert np.allclose(stokes_Mn.Q, 0, atol=1e-20)
+        assert np.allclose(stokes_Mn.U, 0, atol=1e-20)
+        # B=1000 G along LOS: circular polarisation must be present
+        assert np.max(np.abs(stokes_Mn.V)) > 0

--- a/_tests/atom_model/shared/object/test_T_K_Q.py
+++ b/_tests/atom_model/shared/object/test_T_K_Q.py
@@ -2,16 +2,16 @@ import logging
 import unittest
 
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.shared.object.rotations import T_K_Q, T_K_Q_double_rotation, WignerD
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 from solrat.engine.functions.looping import FROMTO, PROJECTION
 from solrat.engine.generators.nested_loops import nested_loops
 
 
 class TestTKQ(unittest.TestCase):
     def test_T_K_Q(self):
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         # A couple of table values
         assert T_K_Q(0, 0, 0, 1, 1, 1) == 1

--- a/_tests/atom_model/shared/object/test_T_K_Q.py
+++ b/_tests/atom_model/shared/object/test_T_K_Q.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 
 import numpy as np
@@ -11,7 +10,7 @@ from solrat.engine.generators.nested_loops import nested_loops
 
 class TestTKQ(unittest.TestCase):
     def test_T_K_Q(self):
-        setup_logging(logging.INFO)
+        setup_logging()
 
         # A couple of table values
         assert T_K_Q(0, 0, 0, 1, 1, 1) == 1

--- a/_tests/atom_model/shared/object/test_wigner_D.py
+++ b/_tests/atom_model/shared/object/test_wigner_D.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 
 import numpy as np
@@ -113,7 +112,7 @@ class TestWignerD(unittest.TestCase):
         Compare T{K, Q} calculated from table 5.5 with T{K, Q} calculated from Wigner D function.
         This simultaneously tests t{K, P}, T{K, Q}, and Wigner D function.
         """
-        setup_logging(logging.INFO)
+        setup_logging()
 
         chi = np.pi / 5
         theta = np.pi / 3

--- a/_tests/atom_model/shared/object/test_wigner_D.py
+++ b/_tests/atom_model/shared/object/test_wigner_D.py
@@ -2,10 +2,10 @@ import logging
 import unittest
 
 import numpy as np
-from yatools import logging_config
 
 from solrat.atom_model.shared.object.rotations import WignerD
 from solrat.atom_model.shared.utility.constants import sqrt2
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 from solrat.engine.functions.looping import FROMTO, PROJECTION
 from solrat.engine.generators.nested_loops import nested_loops
 
@@ -113,7 +113,7 @@ class TestWignerD(unittest.TestCase):
         Compare T{K, Q} calculated from table 5.5 with T{K, Q} calculated from Wigner D function.
         This simultaneously tests t{K, P}, T{K, Q}, and Wigner D function.
         """
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         chi = np.pi / 5
         theta = np.pi / 3

--- a/_tests/atom_model/shared/utility/test_voigt_profile.py
+++ b/_tests/atom_model/shared/utility/test_voigt_profile.py
@@ -2,14 +2,14 @@ import logging
 import unittest
 
 import numpy as np
-from yatools import logging_config
 
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 from solrat.atom_model.shared.utility.voigt_profile import voigt
 
 
 class TestVoigt(unittest.TestCase):
     def test_voigt(self):
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         frequencies = np.linspace(-10, 10, 200)
         for a in [1e-5, 1e-4, 1e-3, 1e-2, 1e-1, 1, 2, 5]:

--- a/_tests/atom_model/shared/utility/test_voigt_profile.py
+++ b/_tests/atom_model/shared/utility/test_voigt_profile.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 
 import numpy as np
@@ -9,7 +8,7 @@ from solrat.atom_model.shared.utility.voigt_profile import voigt
 
 class TestVoigt(unittest.TestCase):
     def test_voigt(self):
-        setup_logging(logging.INFO)
+        setup_logging()
 
         frequencies = np.linspace(-10, 10, 200)
         for a in [1e-5, 1e-4, 1e-3, 1e-2, 1e-1, 1, 2, 5]:

--- a/_tests/atom_model/shared/utility/test_wigner_3j_6j_9j.py
+++ b/_tests/atom_model/shared/utility/test_wigner_3j_6j_9j.py
@@ -2,8 +2,8 @@ import logging
 import unittest
 
 import numpy as np
-from yatools import logging_config
 
+from solrat.atom_model.shared.utility.log_setup import setup_logging
 from solrat.atom_model.shared.utility.wigner_3j_6j_9j import (
     _w3j_doubled_argument,
     _w6j_doubled_argument,
@@ -13,7 +13,7 @@ from solrat.atom_model.shared.utility.wigner_3j_6j_9j import (
 
 class TestMathUtils(unittest.TestCase):
     def test_w3j(self):
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         assert _w3j_doubled_argument(0, 0, 0, 0, 0, 0) == 1
         assert _w3j_doubled_argument(2, 2, 4, 0, 0, 0) == np.sqrt(2 / 15)
@@ -22,7 +22,7 @@ class TestMathUtils(unittest.TestCase):
         assert _w3j_doubled_argument(4, 4, 4, 0, 0, 0) == -np.sqrt(2 / 35)
 
     def test_w6j(self):
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         assert _w6j_doubled_argument(0, 0, 0, 0, 0, 0) == 1
         assert _w6j_doubled_argument(2, 4, 2, 2, 4, 2) == 1 / 30
@@ -31,7 +31,7 @@ class TestMathUtils(unittest.TestCase):
         assert _w6j_doubled_argument(8, 8, 4, 8, 8, 8) == -23 / 1386
 
     def test_w9j(self):
-        logging_config.init(logging.INFO)
+        setup_logging(logging.INFO)
 
         assert _w9j_doubled_argument(0, 0, 0, 0, 0, 0, 0, 0, 0) == 1
         assert abs(_w9j_doubled_argument(8, 8, 10, 8, 8, 10, 8, 8, 8) - 1186 / 184041 * np.sqrt(1 / 7)) < 1e-15

--- a/_tests/atom_model/shared/utility/test_wigner_3j_6j_9j.py
+++ b/_tests/atom_model/shared/utility/test_wigner_3j_6j_9j.py
@@ -13,7 +13,7 @@ from solrat.atom_model.shared.utility.wigner_3j_6j_9j import (
 
 class TestMathUtils(unittest.TestCase):
     def test_w3j(self):
-        setup_logging(logging.INFO)
+        setup_logging()
 
         assert _w3j_doubled_argument(0, 0, 0, 0, 0, 0) == 1
         assert _w3j_doubled_argument(2, 2, 4, 0, 0, 0) == np.sqrt(2 / 15)

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -10,172 +10,115 @@ using a built-in pre-configured model through the public API.
 
 .. code-block:: python
 
-    import logging
-
     import numpy as np
-    from yatools import logging_config
 
     from solrat.atom_model.model_registry import PreconfiguredModels
     from solrat.atom_model.shared.common_api.constant_property_slab import ConstantPropertySlabAtmosphere
     from solrat.atom_model.shared.common_api.multi_slab_atmosphere import MultiSlabAtmosphere
     from solrat.atom_model.shared.object.angles import Angles
     from solrat.atom_model.shared.object.stokes import Stokes
-    from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
+    from solrat.atom_model.shared.utility.functions import get_frequencies_from_air_wavelength_range
+    from solrat.atom_model.shared.utility.log_setup import setup_logging
     from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesPlotter
 
-    # Set up the logger
-    logging_config.init(logging.INFO)
 
-    # Get a built-in pre-configured model for the D3 transition
-    model = PreconfiguredModels.multi_term_atom_HeID3()
-    reference_lambda = model.config.reference_lambda_A
+    def main():
+        """
+        This example demonstrates a minimal workflow for synthesizing the Stokes profiles of the He I D3 line
+        using a built-in pre-configured model through the public API.
 
-    # The calculation itself needs frequency, but we will display the results in wavelength
-    # Define the wavelength grid of interest
-    lambda_A = np.arange(reference_lambda - 0.5, reference_lambda + 0.8, 5e-4)
-    nu = lambda_A_to_frequency_hz(lambda_A)
+        To run this demo, SolRaT needs to be installed.
+        The easiest way is to install SolRaT using "pip install solrat" command.
 
-    # Set up the observation geometry. See Fig. 5.9 in LL04 for reference
-    angles = Angles(
-        chi=0,
-        theta=np.pi/4,
-        gamma=0,
-        chi_B=0,
-        theta_B=0,
-    )
+        You can also clone the repository and run _demos/start_here/demo_basic_stokes_profile_synthesis.py directly.
+        The latter is recommended if you plan to extend available models or creating your own.
+        """
 
-    # Define the atmosphere parameters
-    atmosphere_parameters = model.AtmosphereParameters(
-        model_config=model.config,
-        magnetic_field_gauss=1000,
-        temperature_K=5000,
-    )
+        # Set up the logger. Use setup_logging(logging.DEBUG) for a verbose logging
+        setup_logging()
 
-    # Construct a radiation tensor from the built-in height-stratified parametrization
-    radiation_tensor = model.RadiationTensor.from_model_config(model.config).fill_NLTE_n_w_parametrized(h_arcsec=30)
+        # Get a built-in pre-configured model for the D3 transition
+        # You can browse PreconfiguredModels to see all available pre-configured transfer models.
+        # Additionally, you can configure a transfer model for your own atom.
+        # The latter can be easily done by direct analogy to pre-configured models.
+        model = PreconfiguredModels.multi_term_atom_HeID3()
+        reference_lambda_A_air = model.config.reference_lambda_A_air
 
-    # Set up the initial Stokes vector: zero in this case, corresponding to a limb observation
-    initial_stokes = Stokes.from_zeros(nu_sm1=nu)
-
-    # Define the atmosphere. Here we use a MultiSlabAtmosphere with a single slab
-    atmosphere = MultiSlabAtmosphere(
-        ConstantPropertySlabAtmosphere(
-            model=model,
-            radiation_tensor=radiation_tensor,
-            line_delta_tau=0.1,
-            continuum_delta_tau=0.01,
-            angles=angles,
-            atmosphere_parameters=atmosphere_parameters,
+        # The calculation itself needs frequency, but we will display the results in air wavelength.
+        # Therefore, it is convenient to derive the frequencies from the wavelengths range of interest.
+        # Note that SolRaT scales gracefully with the number of frequency points,
+        # so feel free to request a high spectral resolution.
+        nu = get_frequencies_from_air_wavelength_range(
+            lower_wavelength_A=reference_lambda_A_air - 0.3,
+            upper_wavelength_A=reference_lambda_A_air + 0.6,
+            step_A=5e-3,
         )
-    )
 
-    # Set up a plotter for easier visualization of results
-    plotter = StokesPlotter("Stokes profiles for the He I D3 line")
+        # Set up the observation geometry. See Fig. 5.9 in LL04 for reference
+        # In short:
+        # chi, theta, and gamma are the Euler angles for the Omega (LOS) vector.
+        # chi_B and theta_B are the Euler angles for the magnetic field B vector.
+        angles = Angles(
+            chi=0,
+            theta=np.pi / 4,
+            gamma=0,
+            chi_B=0,
+            theta_B=0,
+        )
 
-    # Calculate the emerging Stokes profiles and add them to the plot
-    plotter.add_stokes(
-        lambda_A=lambda_A,
-        reference_lambda_A=reference_lambda,
-        stokes=atmosphere.forward(initial_stokes=initial_stokes),
-        normalize=True,
-    )
+        # Define the atmosphere parameters
+        atmosphere_parameters = model.AtmosphereParameters(
+            model_config=model.config,
+            magnetic_field_gauss=1000,
+            temperature_K=5000,
+            delta_v_turbulent_cm_sm1=0,  # non-thermal temperature for additional Gaussian broadening
+            macroscopic_velocity_cm_sm1=0,  # Doppler shift, typically used when multiple emission components are modeled
+            voigt_a=0,  # Voigt damping coefficient
+        )
 
-    # Show the plot
-    plotter.show()
+        # Construct a radiation tensor from the built-in height-stratified parametrization
+        # Here we use NLTE J tensor for the height of 30 arcsec above photosphere.
+        # Another option is .fill_planck(self, temperature_K) - fill using LTE Planck distribution
+        radiation_tensor = model.RadiationTensor.from_model_config(model.config).fill_NLTE_n_w_parametrized(h_arcsec=30)
 
-Semi-LTE synthesis of Mn I 5432 A line profiles
------------------------------------------------
-This example demonstrates a workflow for using the semi-LTE model of the Mn I 5432 A line.
+        # Set up the initial Stokes vector: zero in this case, corresponding to a limb observation
+        # Another option is .from_BP(nu_sm1, temperature_K) - fill using LTE Planck distribution
+        initial_stokes = Stokes.from_zeros(nu_sm1=nu)
 
-.. code-block:: python
-
-    import logging
-
-    import numpy as np
-    from yatools import logging_config
-
-    from solrat.atom_model.model_registry import PreconfiguredModels
-    from solrat.atom_model.shared.common_api.constant_property_slab import ConstantPropertySlabAtmosphere
-    from solrat.atom_model.shared.common_api.multi_slab_atmosphere import MultiSlabAtmosphere
-    from solrat.atom_model.shared.object.angles import Angles
-    from solrat.atom_model.shared.object.stokes import Stokes
-    from solrat.atom_model.shared.utility.functions import lambda_A_to_frequency_hz
-    from solrat.atom_model.shared.utility.plot_stokes_profiles import StokesPlotter_IV_IpmV
-
-    # Set up the logger
-    logging_config.init(logging.INFO)
-
-    # Get a built-in pre-configured model for the Mn I 5432 transition
-    model = PreconfiguredModels.multi_term_atom_lte_MnI_5432()
-    reference_lambda = model.config.reference_lambda_A
-
-    # The calculation itself needs frequency, but we will display the results in wavelength
-    # Define the wavelength grid of interest
-    lambda_A = np.arange(reference_lambda + 1.5 - 0.5, reference_lambda + 1.1 + 1, 1e-3)
-    nu = lambda_A_to_frequency_hz(lambda_A)
-
-    # Set up the observation geometry. See Fig. 5.9 in LL04 for reference
-    angles = Angles(chi=0, theta=0, gamma=0, chi_B=0, theta_B=0)
-
-    # Initial Stokes vector: initialize from the Planck's BP at T=5700 K
-    initial_stokes = Stokes.from_BP(nu_sm1=nu, temperature_K=5700)
-
-    # Set up the two-slab atmosphere model
-    atmosphere_Mn = MultiSlabAtmosphere(
-        ConstantPropertySlabAtmosphere(
-            model=model,
-            radiation_tensor=model.RadiationTensor(),
-            line_delta_tau=0.3,
-            continuum_delta_tau=0.01,
-            angles=angles,
-            atmosphere_parameters=model.AtmosphereParameters(
-                model_config=model.config,
-                magnetic_field_gauss=1000,
-                temperature_K=5000,
-                delta_v_turbulent_cm_sm1=1000_00,
-                macroscopic_velocity_cm_sm1=0,
-                voigt_a=0,
+        # Define the atmosphere. Here we use a MultiSlabAtmosphere with a single slab
+        atmosphere = MultiSlabAtmosphere(
+            ConstantPropertySlabAtmosphere(
+                model=model,
+                radiation_tensor=radiation_tensor,
+                line_delta_tau=0.1,  # optical depth of the slab in the line-center frequency
+                continuum_delta_tau=0.001,  # optical depth in the far continuum
+                angles=angles,
+                atmosphere_parameters=atmosphere_parameters,
             ),
-        ),
-        ConstantPropertySlabAtmosphere(
-            model=model,
-            radiation_tensor=model.RadiationTensor(),
-            line_delta_tau=0.2,
-            continuum_delta_tau=0.01,
-            angles=angles,
-            atmosphere_parameters=model.AtmosphereParameters(
-                model_config=model.config,
-                magnetic_field_gauss=2000,
-                temperature_K=6000,
-                delta_v_turbulent_cm_sm1=1000_00,
-                macroscopic_velocity_cm_sm1=0,
-                voigt_a=0,
-            ),
-        ),
-    )
+            # Subsequent slabs can be added here
+        )
 
-    # Calculate the emerging Stokes profiles
-    stokes_Mn = atmosphere_Mn.forward(initial_stokes=initial_stokes)
+        # Set up a plotter for easier visualization of results
+        plotter = StokesPlotter("Stokes profiles for the He I D3 line", reference_lambda_A_air=reference_lambda_A_air)
 
-    # Set up a plotter for easier visualization of results
-    plotter = StokesPlotter_IV_IpmV("Mn I 5432 Line Stokes profiles")
+        # Calculate the emerging Stokes profiles and add them to the plot
+        emerging_stokes = atmosphere.forward(initial_stokes=initial_stokes)
 
-    plotter.add_stokes(
-        lambda_A=lambda_A,
-        reference_lambda_A=1.5,
-        stokes=Stokes(
-            nu=stokes_Mn.nu,
-            I=stokes_Mn.I,
-            Q=stokes_Mn.Q,
-            U=stokes_Mn.U,
-            V=stokes_Mn.V,
-        ),
-        stokes_reference=initial_stokes,  # Use the initial Stokes I as the reference for Stokes profile scaling
-        label="Mn I 5432 line",
-    )
+        # Plot the emerging Stokes profiles
+        plotter.add_stokes(
+            nu=nu,
+            stokes=emerging_stokes,
+            norm=plotter.Norm.MAX_I,  # Normalize using maximum I intensity. Other options: BY_REFERENCE, MAX_IpV_ImV, NONE
+            # stokes_reference=initial_stokes # for on-disk observations, used when norm is BY_REFERENCE.
+            label="$B=1000$ G",
+        )
 
-    plotter.show()
+        # Show the plot
+        plotter.show()
 
+
+    if __name__ == "__main__":
+        main()
 
 Custom Models
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ dependencies = [
     "pandas",
     "matplotlib",
     "tqdm",
-    "yatools",
     "sympy",
     "scipy",
+    "coloredlogs",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/solrat/about.py
+++ b/solrat/about.py
@@ -1,1 +1,1 @@
-version = "1.0.6"
+version = "1.1.0"

--- a/solrat/atom_model/base_atom_model/object/config.py
+++ b/solrat/atom_model/base_atom_model/object/config.py
@@ -6,7 +6,7 @@ class BaseConfig:
     Base config class for atom models.
     """
 
-    reference_lambda_A: float
+    reference_lambda_A_air: float
 
 
 ConfigT = TypeVar("ConfigT", bound=BaseConfig)

--- a/solrat/atom_model/model_registry.py
+++ b/solrat/atom_model/model_registry.py
@@ -1,8 +1,10 @@
+from solrat.engine.functions.decorators import log_method
+
 try:
     from typing import Self  # Python 3.11+
 except ImportError:
     from typing_extensions import Self  # Python <3.11
-
+import logging
 from typing import Generic, Union
 
 from solrat.atom_model.base_atom_model.object.atmosphere_parameters import AtmosphereParametersT
@@ -51,6 +53,7 @@ class Model(Generic[SEET, RTET, RadiationTensorT, AtmosphereParametersT, ConfigT
             raise RuntimeError("config has not been initialized")
         return self._config
 
+    @log_method
     def configure(self, config: ConfigT) -> Self:
         self._config = config
         return self
@@ -59,6 +62,7 @@ class Model(Generic[SEET, RTET, RadiationTensorT, AtmosphereParametersT, ConfigT
 class Models:
     @staticmethod
     def multi_term_atom():
+        logging.info("Creating Multi-Term Atom model")
         return Model[
             MultiTermAtomSEE,
             MultiTermAtomRTE,
@@ -75,6 +79,7 @@ class Models:
 
     @staticmethod
     def multi_term_atom_legacy():
+        logging.info("Creating Multi-Term Atom Legacy model")
         return Model[
             MultiTermAtomSEELegacy,
             MultiTermAtomRTELegacy,
@@ -91,6 +96,8 @@ class Models:
 
     @staticmethod
     def multi_term_atom_lte():
+        logging.info("Creating Multi-Term Atom LTE model")
+
         return Model[
             MultiTermAtomSEELTE,
             MultiTermAtomRTE,

--- a/solrat/atom_model/multi_term_atom_model/data/FeI.py
+++ b/solrat/atom_model/multi_term_atom_model/data/FeI.py
@@ -2,10 +2,10 @@ from solrat.atom_model.multi_term_atom_model.object.level_registry import LevelR
 from solrat.atom_model.multi_term_atom_model.object.multi_term_atom_config import MultiTermAtomConfig
 from solrat.atom_model.multi_term_atom_model.object.transition_registry import TransitionRegistry
 from solrat.atom_model.multi_term_atom_model.utility.paschen_back import get_artificial_S_scale_from_term_g
-from solrat.engine.functions.decorators import log_function
+from solrat.engine.functions.decorators import log_function_experimental
 
 
-@log_function
+@log_function_experimental
 def get_Fe_I_5434_config() -> MultiTermAtomConfig:  # pragma: no cover
     r"""
     Atomic model for Fe I 5434.523 A line, constrained to :math:`J=0 \to J=1` transition.
@@ -60,12 +60,10 @@ def get_Fe_I_5434_config() -> MultiTermAtomConfig:  # pragma: no cover
         + 6.25e04,
     )
 
-    atomic_mass_amu = 55.8
-
     return MultiTermAtomConfig(
         level_registry=level_registry,
         transition_registry=transition_registry,
-        reference_lambda_A=1e8 / (26550.479 - 8154.714),
-        atomic_mass_amu=atomic_mass_amu,
+        reference_lambda_A_air=5434.523,
+        atomic_mass_amu=55.8,
         j_constrained=True,
     )

--- a/solrat/atom_model/multi_term_atom_model/data/FeI.py
+++ b/solrat/atom_model/multi_term_atom_model/data/FeI.py
@@ -65,7 +65,7 @@ def get_Fe_I_5434_config() -> MultiTermAtomConfig:  # pragma: no cover
     return MultiTermAtomConfig(
         level_registry=level_registry,
         transition_registry=transition_registry,
-        reference_lambda_A=5434.523,
+        reference_lambda_A=1e8 / (26550.479 - 8154.714),
         atomic_mass_amu=atomic_mass_amu,
         j_constrained=True,
     )

--- a/solrat/atom_model/multi_term_atom_model/data/HI.py
+++ b/solrat/atom_model/multi_term_atom_model/data/HI.py
@@ -1,8 +1,10 @@
 from solrat.atom_model.multi_term_atom_model.object.level_registry import LevelRegistry
 from solrat.atom_model.multi_term_atom_model.object.multi_term_atom_config import MultiTermAtomConfig
 from solrat.atom_model.multi_term_atom_model.object.transition_registry import TransitionRegistry
+from solrat.engine.functions.decorators import log_function
 
 
+@log_function
 def get_H_I_alpha_config() -> MultiTermAtomConfig:  # pragma: no cover
     r"""
     H alpha line (:math:`3\to 2`)
@@ -91,11 +93,9 @@ def get_H_I_alpha_config() -> MultiTermAtomConfig:  # pragma: no cover
         einstein_a_ul_sm1=2.1046e06 + 4.2097e06,
     )
 
-    # Reference lambda
-    reference_lambda_A = 6563.3
     return MultiTermAtomConfig(
         level_registry=level_registry,
         transition_registry=transition_registry,
         atomic_mass_amu=1,
-        reference_lambda_A=reference_lambda_A,
+        reference_lambda_A_air=6562.79,
     )

--- a/solrat/atom_model/multi_term_atom_model/data/HeI.py
+++ b/solrat/atom_model/multi_term_atom_model/data/HeI.py
@@ -137,7 +137,7 @@ def get_He_I_D3_config() -> MultiTermAtomConfig:  # pragma: no cover
     return MultiTermAtomConfig(
         level_registry=level_registry,
         transition_registry=transition_registry,
-        reference_lambda_A=5877.25,
+        reference_lambda_A_air=5875.621,
         atomic_mass_amu=4.0,
         precomputed_data=precomputed_data,
     )

--- a/solrat/atom_model/multi_term_atom_model/data/MnI.py
+++ b/solrat/atom_model/multi_term_atom_model/data/MnI.py
@@ -56,7 +56,7 @@ def get_Mn_I_5432_config() -> MultiTermAtomConfig:  # pragma: no cover
     return MultiTermAtomConfig(
         level_registry=level_registry,
         transition_registry=transition_registry,
-        reference_lambda_A=5432.5,
+        reference_lambda_A=1e8 / 18402.46,
         atomic_mass_amu=atomic_mass_amu,
         j_constrained=True,
     )

--- a/solrat/atom_model/multi_term_atom_model/data/MnI.py
+++ b/solrat/atom_model/multi_term_atom_model/data/MnI.py
@@ -1,10 +1,10 @@
 from solrat.atom_model.multi_term_atom_model.object.level_registry import LevelRegistry
 from solrat.atom_model.multi_term_atom_model.object.multi_term_atom_config import MultiTermAtomConfig
 from solrat.atom_model.multi_term_atom_model.object.transition_registry import TransitionRegistry
-from solrat.engine.functions.decorators import log_function
+from solrat.engine.functions.decorators import log_function_experimental
 
 
-@log_function
+@log_function_experimental
 def get_Mn_I_5432_config() -> MultiTermAtomConfig:  # pragma: no cover
     r"""
     Atomic model for Mn I 5432.5 A line, constrained to :math:`J=5/2 \to J=5/2` transition.
@@ -52,11 +52,10 @@ def get_Mn_I_5432_config() -> MultiTermAtomConfig:  # pragma: no cover
         einstein_a_ul_sm1=6.04e03,
     )
 
-    atomic_mass_amu = 54.9
     return MultiTermAtomConfig(
         level_registry=level_registry,
         transition_registry=transition_registry,
-        reference_lambda_A=1e8 / 18402.46,
-        atomic_mass_amu=atomic_mass_amu,
+        reference_lambda_A_air=5432.55,
+        atomic_mass_amu=54.9,
         j_constrained=True,
     )

--- a/solrat/atom_model/multi_term_atom_model/data/NiI.py
+++ b/solrat/atom_model/multi_term_atom_model/data/NiI.py
@@ -36,11 +36,10 @@ def get_Ni_I_5435_config() -> MultiTermAtomConfig:  # pragma: no cover
         einstein_a_ul_sm1=1.9e05 + 1.2e5 + 1.1e5 + 2.5e4 + 2.2e5,
     )
 
-    atomic_mass_amu = 58.7
     return MultiTermAtomConfig(
         level_registry=level_registry,
         transition_registry=transition_registry,
-        reference_lambda_A=1e8 / (34408.555 - 16017.306),
-        atomic_mass_amu=atomic_mass_amu,
+        reference_lambda_A_air=5435.87,
+        atomic_mass_amu=58.7,
         j_constrained=True,
     )

--- a/solrat/atom_model/multi_term_atom_model/data/NiI.py
+++ b/solrat/atom_model/multi_term_atom_model/data/NiI.py
@@ -40,7 +40,7 @@ def get_Ni_I_5435_config() -> MultiTermAtomConfig:  # pragma: no cover
     return MultiTermAtomConfig(
         level_registry=level_registry,
         transition_registry=transition_registry,
-        reference_lambda_A=5435.9,
+        reference_lambda_A=1e8 / (34408.555 - 16017.306),
         atomic_mass_amu=atomic_mass_amu,
         j_constrained=True,
     )

--- a/solrat/atom_model/multi_term_atom_model/data/mock.py
+++ b/solrat/atom_model/multi_term_atom_model/data/mock.py
@@ -1,9 +1,10 @@
 from solrat.atom_model.multi_term_atom_model.object.level_registry import LevelRegistry
 from solrat.atom_model.multi_term_atom_model.object.multi_term_atom_config import MultiTermAtomConfig
 from solrat.atom_model.multi_term_atom_model.object.transition_registry import TransitionRegistry
-from solrat.atom_model.shared.utility.functions import frequency_hz_to_lambda_A
+from solrat.engine.functions.decorators import log_function
 
 
+@log_function
 def get_mock_atom_config(fine_structure: bool = True) -> MultiTermAtomConfig:  # pragma: no cover
     r"""
     Ly-alpha-like structure for testing
@@ -48,6 +49,6 @@ def get_mock_atom_config(fine_structure: bool = True) -> MultiTermAtomConfig:  #
     return MultiTermAtomConfig(
         level_registry=level_registry,
         transition_registry=transition_registry,
-        reference_lambda_A=frequency_hz_to_lambda_A(5.996e14),
+        reference_lambda_A_air=4998.4,
         atomic_mass_amu=1.0,
     )

--- a/solrat/atom_model/multi_term_atom_model/object/level_registry.py
+++ b/solrat/atom_model/multi_term_atom_model/object/level_registry.py
@@ -125,6 +125,9 @@ class Term:
         self.artificial_S_scale: Union[float, None] = None
         self.levels: List["Level"] = []
 
+    def __hash__(self):
+        return hash((self.term_id, self.beta, self.L, self.S, self.artificial_S_scale, tuple(self.levels)))
+
     @log_method_experimental
     def set_artificial_spin_scale(self, artificial_S_scale: float):
         r"""

--- a/solrat/atom_model/multi_term_atom_model/object/level_registry.py
+++ b/solrat/atom_model/multi_term_atom_model/object/level_registry.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Dict, List, Union
 
-from solrat.engine.functions.decorators import log_method, log_method_experimental
+from solrat.engine.functions.decorators import VERBOSE, log_method, log_method_experimental
 from solrat.engine.functions.general import half_int_to_str
 from solrat.engine.functions.looping import triangular
 
@@ -59,7 +59,7 @@ class LevelRegistry:
         Register a new term (if not already registered).
         """
         if term_id not in self.terms.keys():
-            logging.info(f"Level registry: Creating term {term_id}")
+            logging.log(VERBOSE, f"Level registry: Creating term {term_id}")
             term = Term(term_id=term_id, beta=beta, L=L, S=S)
             self.terms[term_id] = term
 
@@ -145,6 +145,7 @@ class Term:
         """
         self.artificial_S_scale = artificial_S_scale
 
+    @log_method
     def register_level(self, level: "Level"):
         """
         Register a level to this term.

--- a/solrat/atom_model/multi_term_atom_model/object/multi_term_atom_config.py
+++ b/solrat/atom_model/multi_term_atom_model/object/multi_term_atom_config.py
@@ -12,7 +12,7 @@ class MultiTermAtomConfig(BaseConfig):
         level_registry: LevelRegistry,
         transition_registry: TransitionRegistry,
         atomic_mass_amu: float,
-        reference_lambda_A: float,
+        reference_lambda_A_air: float,
         j_constrained=False,
         disable_r_s: bool = False,
         precomputed_data: Union[PrecomputedData, None] = None,
@@ -25,13 +25,14 @@ class MultiTermAtomConfig(BaseConfig):
         :param level_registry: Registry of atomic energy levels
         :param transition_registry: Registry of radiative transitions
         :param atomic_mass_amu: Atomic mass (in atomic mass units)
+        :param reference_lambda_A_air: air reference wavelength (used for plotting only)
         :param j_constrained: Enable :math:`J` constraint for selecting possible transitions in RTE
         (if constraint is specified in transition registry)
         """
 
         self.level_registry = level_registry
         self.transition_registry = transition_registry
-        self.reference_lambda_A = reference_lambda_A
+        self.reference_lambda_A_air = reference_lambda_A_air
         self.j_constrained = j_constrained
         self.atomic_mass_amu = atomic_mass_amu
         self.disable_r_s = disable_r_s

--- a/solrat/atom_model/multi_term_atom_model/object/radiation_tensor.py
+++ b/solrat/atom_model/multi_term_atom_model/object/radiation_tensor.py
@@ -1,3 +1,5 @@
+from solrat.engine.functions.decorators import log_method
+
 try:
     from typing import Self  # Python 3.11+
 except ImportError:
@@ -14,7 +16,7 @@ from solrat.atom_model.multi_term_atom_model.object.transition_registry import T
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.object.rotations import WignerD
 from solrat.atom_model.shared.utility.constants import c_cm_sm1, h_erg_s, sqrt2
-from solrat.atom_model.shared.utility.functions import frequency_hz_to_lambda_A, get_planck_BP
+from solrat.atom_model.shared.utility.functions import frequency_sm1_to_lambda_A, get_planck_BP
 from solrat.engine.functions.general import delta, half_int_to_str
 from solrat.engine.functions.looping import FROMTO, PROJECTION
 from solrat.engine.generators.nested_loops import nested_loops
@@ -57,17 +59,18 @@ class RadiationTensor(BaseRadiationTensor):
     def get_key(transition_id: str, K: int, Q: int) -> str:
         return f"{transition_id}_{half_int_to_str(K)}_{half_int_to_str(Q)}"
 
-    def fill_planck(self, T_K: float) -> "RadiationTensor":
+    @log_method
+    def fill_planck(self, temperature_K: float) -> "RadiationTensor":
         r"""
         Flat-spectrum approximation, i.e. :math:`J^K_Q` needs to be defined for each transition,
         not for each frequency.
 
-        :param T_K: Temperature in Kelvin
+        :param temperature_K: Temperature in Kelvin
         :return: :any:`RadiationTensor` instance
         """
         for transition in self.transition_registry.transitions.values():
             nu_ul = transition.get_mean_transition_frequency_sm1()
-            planck = get_planck_BP(nu_sm1=nu_ul, T_K=T_K)
+            planck = get_planck_BP(nu_sm1=nu_ul, temperature_K=temperature_K)
             for K, Q in nested_loops(K=FROMTO(0, 2), Q=PROJECTION("K")):
                 key = self.get_key(transition_id=transition.transition_id, K=K, Q=Q)
                 self.data[key] = planck * delta(K, 0) * delta(Q, 0)
@@ -99,6 +102,7 @@ class RadiationTensor(BaseRadiationTensor):
         assert h_arcsec <= 50, "w_fit is not tested for h_arcsec>50"
         return 0.02 + h_arcsec**0.6 * 0.0175 + 4e2 / (lambda_A - 1600 + h_arcsec * 20)
 
+    @log_method
     def fill_NLTE_n_w_parametrized(self, h_arcsec) -> "RadiationTensor":
         r"""
         Fill the radiation tensor with an anisotropic parametrization from A. Asensio Ramos et al (2008)
@@ -112,7 +116,7 @@ class RadiationTensor(BaseRadiationTensor):
         """
         for transition in self.transition_registry.transitions.values():
             nu_ul = transition.get_mean_transition_frequency_sm1()
-            lambda_ul_A = frequency_hz_to_lambda_A(nu_ul)
+            lambda_ul_A = frequency_sm1_to_lambda_A(nu_ul)
 
             J00 = self.n_fit(lambda_ul_A) * 2 * h_erg_s * nu_ul**3 / c_cm_sm1**2
             J20 = J00 * self.w_fit(lambda_ul_A, h_arcsec) / sqrt2
@@ -123,6 +127,7 @@ class RadiationTensor(BaseRadiationTensor):
         self._df = None
         return self
 
+    @log_method
     def get_NLTE_n_w_parametrized_stokes_I(self, h_arcsec, theta, nu):
         r"""
         Get Stokes I that is consistent with the anisotropic {n, w} :math:`J^K_Q` tensor.
@@ -138,7 +143,7 @@ class RadiationTensor(BaseRadiationTensor):
         """
         stokesI = np.zeros_like(nu)
         for i, nui in enumerate(nu):
-            lambdai = frequency_hz_to_lambda_A(nui)
+            lambdai = frequency_sm1_to_lambda_A(nui)
             J00 = self.n_fit(lambdai) * 2 * h_erg_s * nui**3 / c_cm_sm1**2
             J20 = J00 * self.w_fit(lambdai, h_arcsec) / sqrt2
             stokesI[i] = J00 + 5 * J20 * (3 * np.cos(theta) ** 2 - 1) / 2
@@ -181,6 +186,7 @@ class RadiationTensor(BaseRadiationTensor):
                 )
         self._df = pd.concat(dfs, ignore_index=True)
 
+    @log_method
     def rotate(self, D: WignerD) -> "RadiationTensor":
         r"""
         Rotate the :math:`J^K_Q` tensor according to the :math:`D` rotation.
@@ -204,6 +210,7 @@ class RadiationTensor(BaseRadiationTensor):
                 )
         return new_J
 
+    @log_method
     def rotate_to_magnetic_frame(self, angles: Angles) -> "RadiationTensor":
         r"""
         Rotate :math:`J^K_Q` to the magnetic reference frame.

--- a/solrat/atom_model/multi_term_atom_model/object/transition_registry.py
+++ b/solrat/atom_model/multi_term_atom_model/object/transition_registry.py
@@ -20,6 +20,15 @@ class TransitionRegistry:
     def __init__(self):
         self.transitions: Dict[str, "Transition"] = {}
 
+    def einstein_b_lu(self, transition_id: str) -> float:
+        return self.transitions[transition_id].einstein_b_lu
+
+    def einstein_b_ul(self, transition_id: str) -> float:
+        return self.transitions[transition_id].einstein_b_ul
+
+    def einstein_a_ul(self, transition_id: str) -> float:
+        return self.transitions[transition_id].einstein_a_ul
+
     def register_transition(
         self,
         term_upper: Term,

--- a/solrat/atom_model/multi_term_atom_model/object/transition_registry.py
+++ b/solrat/atom_model/multi_term_atom_model/object/transition_registry.py
@@ -5,7 +5,8 @@ from solrat.atom_model.multi_term_atom_model.utility.einstein_coefficients impor
     b_lu_from_b_ul_multi_term_atom,
     b_ul_from_a_ul_multi_term_atom,
 )
-from solrat.atom_model.shared.utility.functions import energy_cmm1_to_frequency_hz
+from solrat.atom_model.shared.utility.functions import energy_cmm1_to_frequency_sm1
+from solrat.engine.functions.decorators import log_method
 
 
 class TransitionRegistry:
@@ -29,6 +30,7 @@ class TransitionRegistry:
     def einstein_a_ul(self, transition_id: str) -> float:
         return self.transitions[transition_id].einstein_a_ul
 
+    @log_method
     def register_transition(
         self,
         term_upper: Term,
@@ -50,7 +52,7 @@ class TransitionRegistry:
 
         transition_id = term_upper.term_id + "->" + term_lower.term_id
         assert transition_id not in self.transitions.keys()
-        nu_ul = energy_cmm1_to_frequency_hz(term_upper.get_mean_energy_cmm1() - term_lower.get_mean_energy_cmm1())
+        nu_ul = energy_cmm1_to_frequency_sm1(term_upper.get_mean_energy_cmm1() - term_lower.get_mean_energy_cmm1())
 
         b_ul = b_ul_from_a_ul_multi_term_atom(a_ul_sm1=einstein_a_ul_sm1, nu_ul=nu_ul)
         b_lu = b_lu_from_b_ul_multi_term_atom(b_ul=b_ul, Lu=term_upper.L, Ll=term_lower.L)
@@ -135,6 +137,6 @@ class Transition:
         A crude approximation for the 'central' frequency of the transition.
         Should be used only in non-frequency-sensitive expressions like filling out Planck's function in LTE.
         """
-        return energy_cmm1_to_frequency_hz(
+        return energy_cmm1_to_frequency_sm1(
             self.term_upper.get_mean_energy_cmm1() - self.term_lower.get_mean_energy_cmm1()
         )

--- a/solrat/atom_model/multi_term_atom_model/radiative_transfer_equations.py
+++ b/solrat/atom_model/multi_term_atom_model/radiative_transfer_equations.py
@@ -4,6 +4,7 @@ except ImportError:
     from typing_extensions import Self  # Python <3.11
 
 import logging
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -15,10 +16,10 @@ from solrat.atom_model.multi_term_atom_model.object.level_registry import LevelR
 from solrat.atom_model.multi_term_atom_model.object.multi_term_atom_config import MultiTermAtomConfig
 from solrat.atom_model.multi_term_atom_model.object.rho_matrix_builder import Rho
 from solrat.atom_model.multi_term_atom_model.object.transition_registry import TransitionRegistry
-from solrat.atom_model.multi_term_atom_model.utility.paschen_back import calculate_paschen_back
+from solrat.atom_model.multi_term_atom_model.utility.paschen_back import PaschenBack
 from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.object.radiative_transfer_coefficients import RadiativeTransferCoefficients
-from solrat.atom_model.shared.object.rotations import T_K_Q_double_rotation, WignerD
+from solrat.atom_model.shared.object.rotations import T_K_Q_double_rotation_all_stokes, WignerD
 from solrat.atom_model.shared.utility.constants import c_cm_sm1, h_erg_s, sqrt_pi
 from solrat.atom_model.shared.utility.functions import energy_cmm1_to_frequency_hz
 from solrat.atom_model.shared.utility.voigt_profile import voigt
@@ -46,7 +47,7 @@ class MultiTermAtomRTE(BaseRTE):
     :param nu:  frequencies [Hz]
     :param custom_delta_nu_cutoff:  distance in frequency for cutting off irrelevant transitions.
         Leave None for a conservative default value.
-    :param N:  atom numeric concentration for real space (as opposed to density) modeling.
+    :param N:  atom numeric concentration for d/dz transfer modeling. Can be left equal to 1 for d/dtau modeling.
     :param j_constrained:  constrain J values to the ones specified in transition_registry.
         This parameter is useful for modeling lines like Fe5434 where fine structure components are scattered
         over a very broad spectral interval, while the user is interested only in a specific transition.
@@ -74,6 +75,15 @@ class MultiTermAtomRTE(BaseRTE):
         self.N = N
         self.j_constrained = j_constrained
 
+        # Shorter getters for Einstein coefficients
+        self.paschen_back = PaschenBack(level_registry=level_registry)
+        self.einstein_b_lu = np.vectorize(self.transition_registry.einstein_b_lu)
+        self.einstein_b_ul = np.vectorize(self.transition_registry.einstein_b_ul)
+
+        # Precomputed frames
+        self.eta_rho_a_frame: Union[Frame, None] = None
+        self.eta_rho_s_frame: Union[Frame, None] = None
+
     @classmethod
     def from_model_config(
         cls,
@@ -94,192 +104,155 @@ class MultiTermAtomRTE(BaseRTE):
         )
 
     @log_method
-    def calculate_eta_rho_a(
-        self,
-        stokes_component_index: int,
-        angles: Angles,
-        rho: Rho,
-        atmosphere_parameters: AtmosphereParameters,
-    ) -> np.ndarray:
+    def calculate_eta_rho_a(self, angles: Angles, rho: Rho, atmosphere_parameters: AtmosphereParameters) -> np.ndarray:
         r"""
-        Calculate etaA and rhoA for selected Stokes component
+        Calculate etaA and rhoA for all Stokes components simultaneously.
 
-        :param stokes_component_index:  denotes Stokes component (0=I 1=Q 2=U 3=V)
         :param angles:  Angles instance with LOS and magnetic field angles
         :param rho:  density tensor Rho
         :param atmosphere_parameters:  AtmosphereParameters instance
-        :return: complex array of :math:`\eta_A + i \rho_A` vs frequency
+        :return: complex array of :math:`\eta_A + i \rho_A` vs frequency, shape [4, len(nu)] for I, Q, U, V
 
         Reference: (LL04 7.47 ac)
         """
-        sum_limits = self.AFrameSumLimitsConstrained() if self.j_constrained else self.AFrameSumLimits()
+        magnetic_field_gauss = atmosphere_parameters.magnetic_field_gauss
 
-        frame = Frame.from_sum_limits(
-            base_frame=self.create_base_frame(),
-            sum_limits=sum_limits,
-        )
+        if self.eta_rho_a_frame is None:
+            # If no cached frame available, calculate atmosphere-independent part and save
+            frame = Frame.from_sum_limits(
+                base_frame=self.create_base_frame(),
+                sum_limits=self.AFrameSumLimitsConstrained() if self.j_constrained else self.AFrameSumLimits(),
+            )
 
-        # Preparation:
+            frame.register_multiplication(
+                a001=lambda Ll:                          n_proj(Ll),
+                a002=lambda transition_id, K, Kl:        self.einstein_b_lu(transition_id) * sqrt(n_proj(1, K, Kl)),
+                a003=lambda Jʹʹl, Ml, qʹ:                m1p(1 + Jʹʹl - Ml + qʹ),
+                a004=lambda Jl, Jʹl, Ju, Jʹu:            sqrt(n_proj(Jl, Jʹl, Ju, Jʹu)),
+                w3j1=lambda Ju, Jl, Mu, Ml, q:           wigner_3j(Ju, Jl, 1, -Mu, Ml, -q),
+                w3j2=lambda Jʹu, Jʹl, Mu, Mʹl, qʹ:       wigner_3j(Jʹu, Jʹl, 1, -Mu, Mʹl, -qʹ),
+                w3j3=lambda K, q, qʹ, Q:                 wigner_3j(1, 1, K, q, -qʹ, -Q),
+                w3j4=lambda Jʹʹl, Jʹl, Kl, Ml, Mʹl, Ql:  wigner_3j(Jʹʹl, Jʹl, Kl, Ml, -Mʹl, -Ql),
+                w6j1=lambda Lu, Ll, Jl, Ju, S:           wigner_6j(Lu, Ll, 1, Jl, Ju, S),
+                w6j2=lambda Lu, Ll, Jʹl, Jʹu, S:         wigner_6j(Lu, Ll, 1, Jʹl, Jʹu, S),
+            )  # fmt: skip
+
+            self.eta_rho_a_frame = frame.copy()
+        else:
+            frame = self.eta_rho_a_frame.copy()
+
         D_inverse_omega = WignerD(alpha=-angles.gamma, beta=-angles.theta, gamma=-angles.chi, K_max=2)
         D_magnetic = WignerD(alpha=angles.chi_B, beta=angles.theta_B, gamma=0, K_max=2)
-        precalculated_pb_eigenvalues = {}
-        precalculated_pb_eigenvectors = {}
-
-        for term in self.level_registry.terms.values():
-            pb_eigenvalues, pb_eigenvectors = calculate_paschen_back(
-                term=term, magnetic_field_gauss=atmosphere_parameters.magnetic_field_gauss
-            )
-            precalculated_pb_eigenvalues[term.term_id] = pb_eigenvalues
-            precalculated_pb_eigenvectors[term.term_id] = pb_eigenvectors
 
         frame.register_multiplication(
-            a001=lambda Ll:                          n_proj(Ll),
-            a002=lambda einstein_b_lu, K, Kl:        einstein_b_lu * sqrt(n_proj(1, K, Kl)),
-            a003=lambda Jʹʹl, Ml, qʹ:                m1p(1 + Jʹʹl - Ml + qʹ),
-            a004=lambda Jl, Jʹl, Ju, Jʹu:            sqrt(n_proj(Jl, Jʹl, Ju, Jʹu)),
-            w3j1=lambda Ju, Jl, Mu, Ml, q:           wigner_3j(Ju, Jl, 1, -Mu, Ml, -q),
-            w3j2=lambda Jʹu, Jʹl, Mu, Mʹl, qʹ:       wigner_3j(Jʹu, Jʹl, 1, -Mu, Mʹl, -qʹ),
-            w3j3=lambda K, q, qʹ, Q:                 wigner_3j(1, 1, K, q, -qʹ, -Q),
-            w3j4=lambda Jʹʹl, Jʹl, Kl, Ml, Mʹl, Ql:  wigner_3j(Jʹʹl, Jʹl, Kl, Ml, -Mʹl, -Ql),
-            w6j1=lambda Lu, Ll, Jl, Ju, S:           wigner_6j(Lu, Ll, 1, Jl, Ju, S),
-            w6j2=lambda Lu, Ll, Jʹl, Jʹu, S:         wigner_6j(Lu, Ll, 1, Jʹl, Jʹu, S),
-        )  # fmt: skip
-
-        frame.register_multiplication(
-            tkq=lambda K, Q: T_K_Q_double_rotation(
-                K=K,
-                Q=Q,
-                stokes_component_index=stokes_component_index,
-                D_inverse_omega=D_inverse_omega,
-                D_magnetic=D_magnetic,
+            tkq=lambda K, Q: T_K_Q_double_rotation_all_stokes(
+                K=K, Q=Q, D_inverse_omega=D_inverse_omega, D_magnetic=D_magnetic
             ),
-            pb1=lambda term_lower_id, jl, Jl, Ml: precalculated_pb_eigenvectors[term_lower_id](j=jl, J=Jl, M=Ml),
-            pb2=lambda term_lower_id, jl, Jʹʹl, Ml: precalculated_pb_eigenvectors[term_lower_id](j=jl, J=Jʹʹl, M=Ml),
-            pb3=lambda term_upper_id, ju, Ju, Mu: precalculated_pb_eigenvectors[term_upper_id](j=ju, J=Ju, M=Mu),
-            pb4=lambda term_upper_id, ju, Jʹu, Mu: precalculated_pb_eigenvectors[term_upper_id](j=ju, J=Jʹu, M=Mu),
+            pb1=lambda term_lower_id, jl, Jl, Ml: self.paschen_back.eigenvector(
+                term_id=term_lower_id, j=jl, J=Jl, M=Ml, magnetic_field_gauss=magnetic_field_gauss
+            ),
+            pb2=lambda term_lower_id, jl, Jʹʹl, Ml: self.paschen_back.eigenvector(
+                term_id=term_lower_id, j=jl, J=Jʹʹl, M=Ml, magnetic_field_gauss=magnetic_field_gauss
+            ),
+            pb3=lambda term_upper_id, ju, Ju, Mu: self.paschen_back.eigenvector(
+                term_id=term_upper_id, j=ju, J=Ju, M=Mu, magnetic_field_gauss=magnetic_field_gauss
+            ),
+            pb4=lambda term_upper_id, ju, Jʹu, Mu: self.paschen_back.eigenvector(
+                term_id=term_upper_id, j=ju, J=Jʹu, M=Mu, magnetic_field_gauss=magnetic_field_gauss
+            ),
             rho=lambda term_lower_id, Kl, Ql, Jʹʹl, Jʹl: rho(term_id=term_lower_id, K=Kl, Q=Ql, J=Jʹʹl, Jʹ=Jʹl),
             phi=lambda ju, Mu, term_upper_id, jl, Ml, term_lower_id: self.phi(
-                nui=energy_cmm1_to_frequency_hz(
-                    precalculated_pb_eigenvalues[term_upper_id](j=ju, M=Mu)
-                    - precalculated_pb_eigenvalues[term_lower_id](j=jl, M=Ml)
-                ),
-                nu=self.nu,
-                macroscopic_velocity_cm_sm1=atmosphere_parameters.macroscopic_velocity_cm_sm1,
-                delta_v_thermal_cm_sm1=atmosphere_parameters.delta_v_thermal_cm_sm1,
-                voigt_a=atmosphere_parameters.voigt_a,
+                term_upper_id=term_upper_id,
+                ju=ju,
+                Mu=Mu,
+                term_lower_id=term_lower_id,
+                jl=jl,
+                Ml=Ml,
+                atmosphere_parameters=atmosphere_parameters,
             ),
             elementwise=True,
         )
 
-        result = frame.reduce(
-            sum_limits.K,
-            sum_limits.Q,
-            sum_limits.Ju,
-            sum_limits.Jʹu,
-            sum_limits.Jl,
-            sum_limits.Kl,
-            sum_limits.Ql,
-            sum_limits.Jʹʹl,
-            sum_limits.Jʹl,
-            ...,  # Ellipsis means reduce all remaining indexes
-        )
+        result = frame.reduce("K", "Q", "Ju", "Jʹu", "Jl", "Kl", "Ql", "Jʹʹl", "Jʹl", ...)
         result = h_erg_s * self.nu / 4 / pi * self.N * result
         return result
 
     @log_method
-    def calculate_eta_rho_s(
-        self,
-        stokes_component_index: int,
-        angles: Angles,
-        rho: Rho,
-        atmosphere_parameters: AtmosphereParameters,
-    ):
+    def calculate_eta_rho_s(self, angles: Angles, rho: Rho, atmosphere_parameters: AtmosphereParameters) -> np.ndarray:
         r"""
-        Calculate etaS and rhoS for selected Stokes component
+        Calculate etaS and rhoS for all Stokes components simultaneously.
 
-        :param stokes_component_index:  denotes Stokes component (0=I 1=Q 2=U 3=V)
         :param angles:  Angles instance with LOS and magnetic field angles
         :param rho:  density tensor Rho
         :param atmosphere_parameters:  AtmosphereParameters instance
-        :return: complex array of :math:`\eta_S + i \rho_S` vs frequency
+        :return: complex array of :math:`\eta_S + i \rho_S` vs frequency, shape [4, len(nu)] for I, Q, U, V
 
         Reference: (LL04 7.47 bd)
         """
-        sum_limits = self.SFrameSumLimitsConstrained() if self.j_constrained else self.SFrameSumLimits()
+        magnetic_field_gauss = atmosphere_parameters.magnetic_field_gauss
 
-        frame = Frame.from_sum_limits(
-            base_frame=self.create_base_frame(),
-            sum_limits=sum_limits,
-        )
+        if self.eta_rho_s_frame is None:
+            # If no cached frame available, calculate atmosphere-independent part and save
 
-        # Preparation:
+            frame = Frame.from_sum_limits(
+                base_frame=self.create_base_frame(),
+                sum_limits=self.SFrameSumLimitsConstrained() if self.j_constrained else self.SFrameSumLimits(),
+            )
+
+            frame.register_multiplication(
+                a001=lambda Lu: n_proj(Lu),
+                a002=lambda transition_id, K, Ku: self.einstein_b_ul(transition_id) * sqrt(n_proj(1, K, Ku)),
+                a003=lambda Jʹu, Mu, qʹ: m1p(1 + Jʹu - Mu + qʹ),
+                a004=lambda Jl, Jʹl, Ju, Jʹu: sqrt(n_proj(Jl, Jʹl, Ju, Jʹu)),
+                w3j1=lambda Ju, Jl, Mu, Ml, q: wigner_3j(Ju, Jl, 1, -Mu, Ml, -q),
+                w3j2=lambda Jʹu, Jʹl, Mʹu, Ml, qʹ: wigner_3j(Jʹu, Jʹl, 1, -Mʹu, Ml, -qʹ),
+                w3j3=lambda K, q, qʹ, Q: wigner_3j(1, 1, K, q, -qʹ, -Q),
+                w3j4=lambda Jʹʹu, Jʹu, Ku, Mu, Mʹu, Qu: wigner_3j(Jʹu, Jʹʹu, Ku, Mʹu, -Mu, -Qu),
+                w6j1=lambda Lu, Ll, Jl, Ju, S: wigner_6j(Lu, Ll, 1, Jl, Ju, S),
+                w6j2=lambda Lu, Ll, Jʹl, Jʹu, S: wigner_6j(Lu, Ll, 1, Jʹl, Jʹu, S),
+            )  # fmt: skip
+            self.eta_rho_s_frame = frame.copy()
+        else:
+            frame = self.eta_rho_s_frame.copy()
+
         D_inverse_omega = WignerD(alpha=-angles.gamma, beta=-angles.theta, gamma=-angles.chi, K_max=2)
         D_magnetic = WignerD(alpha=angles.chi_B, beta=angles.theta_B, gamma=0, K_max=2)
-        precalculated_pb_eigenvalues = {}
-        precalculated_pb_eigenvectors = {}
-        for term in self.level_registry.terms.values():
-            pb_eigenvalues, pb_eigenvectors = calculate_paschen_back(
-                term=term, magnetic_field_gauss=atmosphere_parameters.magnetic_field_gauss
-            )
-            precalculated_pb_eigenvalues[term.term_id] = pb_eigenvalues
-            precalculated_pb_eigenvectors[term.term_id] = pb_eigenvectors
 
         frame.register_multiplication(
-            a001=lambda Lu:                          n_proj(Lu),
-            a002=lambda einstein_b_ul, K, Ku:        einstein_b_ul * sqrt(n_proj(1, K, Ku)),
-            a003=lambda Jʹu, Mu, qʹ:                 m1p(1 + Jʹu - Mu + qʹ),
-            a004=lambda Jl, Jʹl, Ju, Jʹu:            sqrt(n_proj(Jl, Jʹl, Ju, Jʹu)),
-            w3j1=lambda Ju, Jl, Mu, Ml, q:           wigner_3j(Ju, Jl, 1, -Mu, Ml, -q),
-            w3j2=lambda Jʹu, Jʹl, Mʹu, Ml, qʹ:       wigner_3j(Jʹu, Jʹl, 1, -Mʹu, Ml, -qʹ),
-            w3j3=lambda K, q, qʹ, Q:                 wigner_3j(1, 1, K, q, -qʹ, -Q),
-            w3j4=lambda Jʹʹu, Jʹu, Ku, Mu, Mʹu, Qu:  wigner_3j(Jʹu, Jʹʹu, Ku, Mʹu, -Mu, -Qu),
-            w6j1=lambda Lu, Ll, Jl, Ju, S:           wigner_6j(Lu, Ll, 1, Jl, Ju, S),
-            w6j2=lambda Lu, Ll, Jʹl, Jʹu, S:         wigner_6j(Lu, Ll, 1, Jʹl, Jʹu, S),
-        )  # fmt: skip
-
-        frame.register_multiplication(
-            tkq=lambda K, Q: T_K_Q_double_rotation(
-                K=K,
-                Q=Q,
-                stokes_component_index=stokes_component_index,
-                D_inverse_omega=D_inverse_omega,
-                D_magnetic=D_magnetic,
+            tkq=lambda K, Q: T_K_Q_double_rotation_all_stokes(
+                K=K, Q=Q, D_inverse_omega=D_inverse_omega, D_magnetic=D_magnetic
             ),
-            pb1=lambda term_lower_id, jl, Jl, Ml: precalculated_pb_eigenvectors[term_lower_id](j=jl, J=Jl, M=Ml),
-            pb2=lambda term_lower_id, jl, Jʹl, Ml: precalculated_pb_eigenvectors[term_lower_id](j=jl, J=Jʹl, M=Ml),
-            pb3=lambda term_upper_id, ju, Ju, Mu: precalculated_pb_eigenvectors[term_upper_id](j=ju, J=Ju, M=Mu),
-            pb4=lambda term_upper_id, ju, Jʹʹu, Mu: precalculated_pb_eigenvectors[term_upper_id](j=ju, J=Jʹʹu, M=Mu),
+            pb1=lambda term_lower_id, jl, Jl, Ml: self.paschen_back.eigenvector(
+                term_id=term_lower_id, j=jl, J=Jl, M=Ml, magnetic_field_gauss=magnetic_field_gauss
+            ),
+            pb2=lambda term_lower_id, jl, Jʹl, Ml: self.paschen_back.eigenvector(
+                term_id=term_lower_id, j=jl, J=Jʹl, M=Ml, magnetic_field_gauss=magnetic_field_gauss
+            ),
+            pb3=lambda term_upper_id, ju, Ju, Mu: self.paschen_back.eigenvector(
+                term_id=term_upper_id, j=ju, J=Ju, M=Mu, magnetic_field_gauss=magnetic_field_gauss
+            ),
+            pb4=lambda term_upper_id, ju, Jʹʹu, Mu: self.paschen_back.eigenvector(
+                term_id=term_upper_id, j=ju, J=Jʹʹu, M=Mu, magnetic_field_gauss=magnetic_field_gauss
+            ),
             rho=lambda term_upper_id, Ku, Qu, Jʹʹu, Jʹu: rho(term_id=term_upper_id, K=Ku, Q=Qu, J=Jʹu, Jʹ=Jʹʹu),
             phi=lambda ju, Mu, term_upper_id, jl, Ml, term_lower_id: self.phi(
-                nui=energy_cmm1_to_frequency_hz(
-                    precalculated_pb_eigenvalues[term_upper_id](j=ju, M=Mu)
-                    - precalculated_pb_eigenvalues[term_lower_id](j=jl, M=Ml)
-                ),
-                nu=self.nu,
-                macroscopic_velocity_cm_sm1=atmosphere_parameters.macroscopic_velocity_cm_sm1,
-                delta_v_thermal_cm_sm1=atmosphere_parameters.delta_v_thermal_cm_sm1,
-                voigt_a=atmosphere_parameters.voigt_a,
+                term_upper_id=term_upper_id,
+                ju=ju,
+                Mu=Mu,
+                term_lower_id=term_lower_id,
+                jl=jl,
+                Ml=Ml,
+                atmosphere_parameters=atmosphere_parameters,
             ),
             elementwise=True,
         )
 
-        result = frame.reduce(
-            sum_limits.K,
-            sum_limits.Q,
-            sum_limits.Jl,
-            sum_limits.Jʹl,
-            sum_limits.Ju,
-            sum_limits.Ku,
-            sum_limits.Qu,
-            sum_limits.Jʹu,
-            sum_limits.Jʹʹu,
-            ...,  # Ellipsis means reduce all remaining indexes
-        )
+        result = frame.reduce("K", "Q", "Jl", "Jʹl", "Ju", "Ku", "Qu", "Jʹu", "Jʹʹu", ...)
         result = h_erg_s * self.nu / 4 / pi * self.N * result
         return result
 
     @staticmethod
-    def compute_epsilon(eta_s: np.ndarray, nu: np.ndarray) -> np.ndarray:
+    def calculate_epsilon(eta_s: np.ndarray, nu: np.ndarray) -> np.ndarray:
         r"""
         Compute :math:`\epsilon` given :math:`\eta_S`
 
@@ -309,9 +282,6 @@ class MultiTermAtomRTE(BaseRTE):
 
             row_dict = {
                 "transition_id": transition.transition_id,
-                "einstein_b_lu": transition.einstein_b_lu,
-                "einstein_b_ul": transition.einstein_b_ul,
-                "einstein_a_ul": transition.einstein_a_ul,
                 "term_upper_id": term_upper.term_id,
                 "term_lower_id": term_lower.term_id,
                 "Ll": term_lower.L,
@@ -342,78 +312,35 @@ class MultiTermAtomRTE(BaseRTE):
 
         Reference: (LL04 7.47)
         """
-        eta_rho_aI = self.calculate_eta_rho_a(
-            stokes_component_index=0,
+        eta_rho_a = self.calculate_eta_rho_a(
             angles=angles,
             rho=rho,
             atmosphere_parameters=atmosphere_parameters,
-        )
-        eta_rho_aQ = self.calculate_eta_rho_a(
-            stokes_component_index=1,
-            angles=angles,
-            rho=rho,
-            atmosphere_parameters=atmosphere_parameters,
-        )
-        eta_rho_aU = self.calculate_eta_rho_a(
-            stokes_component_index=2,
-            angles=angles,
-            rho=rho,
-            atmosphere_parameters=atmosphere_parameters,
-        )
-        eta_rho_aV = self.calculate_eta_rho_a(
-            stokes_component_index=3,
-            angles=angles,
-            rho=rho,
-            atmosphere_parameters=atmosphere_parameters,
-        )
+        )  # shape [4, len(nu)]: I, Q, U, V
 
-        eta_rho_sI = self.calculate_eta_rho_s(
-            stokes_component_index=0,
+        eta_rho_s = self.calculate_eta_rho_s(
             angles=angles,
             rho=rho,
             atmosphere_parameters=atmosphere_parameters,
-        )
-        eta_rho_sQ = self.calculate_eta_rho_s(
-            stokes_component_index=1,
-            angles=angles,
-            rho=rho,
-            atmosphere_parameters=atmosphere_parameters,
-        )
-        eta_rho_sU = self.calculate_eta_rho_s(
-            stokes_component_index=2,
-            angles=angles,
-            rho=rho,
-            atmosphere_parameters=atmosphere_parameters,
-        )
-        eta_rho_sV = self.calculate_eta_rho_s(
-            stokes_component_index=3,
-            angles=angles,
-            rho=rho,
-            atmosphere_parameters=atmosphere_parameters,
-        )
-
-        epsilonI = self.compute_epsilon(eta_s=eta_rho_sI, nu=self.nu)
-        epsilonQ = self.compute_epsilon(eta_s=eta_rho_sQ, nu=self.nu)
-        epsilonU = self.compute_epsilon(eta_s=eta_rho_sU, nu=self.nu)
-        epsilonV = self.compute_epsilon(eta_s=eta_rho_sV, nu=self.nu)
+        )  # shape [4, len(nu)]: I, Q, U, V
 
         return RadiativeTransferCoefficients(
-            eta_rho_aI=eta_rho_aI,
-            eta_rho_aQ=eta_rho_aQ,
-            eta_rho_aU=eta_rho_aU,
-            eta_rho_aV=eta_rho_aV,
-            eta_rho_sI=eta_rho_sI,
-            eta_rho_sQ=eta_rho_sQ,
-            eta_rho_sU=eta_rho_sU,
-            eta_rho_sV=eta_rho_sV,
-            epsilonI=epsilonI,
-            epsilonQ=epsilonQ,
-            epsilonU=epsilonU,
-            epsilonV=epsilonV,
+            eta_rho_aI=eta_rho_a[0],
+            eta_rho_aQ=eta_rho_a[1],
+            eta_rho_aU=eta_rho_a[2],
+            eta_rho_aV=eta_rho_a[3],
+            eta_rho_sI=eta_rho_s[0],
+            eta_rho_sQ=eta_rho_s[1],
+            eta_rho_sU=eta_rho_s[2],
+            eta_rho_sV=eta_rho_s[3],
+            epsilonI=self.calculate_epsilon(eta_s=eta_rho_s[0], nu=self.nu),
+            epsilonQ=self.calculate_epsilon(eta_s=eta_rho_s[1], nu=self.nu),
+            epsilonU=self.calculate_epsilon(eta_s=eta_rho_s[2], nu=self.nu),
+            epsilonV=self.calculate_epsilon(eta_s=eta_rho_s[3], nu=self.nu),
         )
 
     @staticmethod
-    def phi(
+    def _phi(
         nui: float, nu: np.ndarray, macroscopic_velocity_cm_sm1: float, delta_v_thermal_cm_sm1: float, voigt_a: float
     ) -> np.ndarray:
         """
@@ -430,6 +357,28 @@ class MultiTermAtomRTE(BaseRTE):
 
         complex_voigt = voigt(nu=nu_round - nu_round_A, a=voigt_a) / sqrt_pi / delta_nu_D
         return complex_voigt
+
+    def phi(self, term_upper_id, ju, Mu, term_lower_id, jl, Ml, atmosphere_parameters):
+        return self._phi(
+            nui=energy_cmm1_to_frequency_hz(
+                self.paschen_back.eigenvalue(
+                    term_id=term_upper_id,
+                    j=ju,
+                    M=Mu,
+                    magnetic_field_gauss=atmosphere_parameters.magnetic_field_gauss,
+                )
+                - self.paschen_back.eigenvalue(
+                    term_id=term_lower_id,
+                    j=jl,
+                    M=Ml,
+                    magnetic_field_gauss=atmosphere_parameters.magnetic_field_gauss,
+                )
+            ),
+            nu=self.nu,
+            macroscopic_velocity_cm_sm1=atmosphere_parameters.macroscopic_velocity_cm_sm1,
+            delta_v_thermal_cm_sm1=atmosphere_parameters.delta_v_thermal_cm_sm1,
+            voigt_a=atmosphere_parameters.voigt_a,
+        )
 
     def cutoff_condition(self, term_upper: Term, term_lower: Term, nu: np.ndarray):
         r"""
@@ -455,7 +404,6 @@ class MultiTermAtomRTE(BaseRTE):
         Ll = DummyOrAlreadyMerged(term_lower_id)  # Pre-merged to base_frame
         Lu = DummyOrAlreadyMerged(term_upper_id)  # Pre-merged to base_frame
         S = DummyOrAlreadyMerged(term_lower_id)  # Pre-merged to base_frame
-        einstein_b_lu = DummyOrAlreadyMerged(term_lower_id)  # Pre-merged to base_frame
         jl = Triangular(Ll, S)
         Jl = Triangular(Ll, S)
         Jʹl = Triangular(Ll, S)
@@ -484,7 +432,6 @@ class MultiTermAtomRTE(BaseRTE):
         Ll = DummyOrAlreadyMerged(term_lower_id)  # Pre-merged to base_frame
         Lu = DummyOrAlreadyMerged(term_upper_id)  # Pre-merged to base_frame
         S = DummyOrAlreadyMerged(term_lower_id)  # Pre-merged to base_frame
-        einstein_b_lu = DummyOrAlreadyMerged(term_lower_id)  # Pre-merged to base_frame
         lower_J_constraint = Constraint()  # Artificial constraint for J to model only selected transitions
         upper_J_constraint = Constraint()  # Artificial constraint for J to model only selected transitions
         jl = ApplyConstraint(Triangular(Ll, S), lower_J_constraint)
@@ -515,7 +462,6 @@ class MultiTermAtomRTE(BaseRTE):
         Ll = DummyOrAlreadyMerged(term_lower_id)  # Pre-merged to base_frame
         Lu = DummyOrAlreadyMerged(term_upper_id)  # Pre-merged to base_frame
         S = DummyOrAlreadyMerged(term_lower_id)  # Pre-merged to base_frame
-        einstein_b_ul = DummyOrAlreadyMerged(term_lower_id)  # Pre-merged to base_frame
         ju = Triangular(Lu, S)
         Ju = Triangular(Lu, S)
         Jʹu = Triangular(Lu, S)
@@ -544,7 +490,6 @@ class MultiTermAtomRTE(BaseRTE):
         Ll = DummyOrAlreadyMerged(term_lower_id)  # Pre-merged to base_frame
         Lu = DummyOrAlreadyMerged(term_upper_id)  # Pre-merged to base_frame
         S = DummyOrAlreadyMerged(term_lower_id)  # Pre-merged to base_frame
-        einstein_b_ul = DummyOrAlreadyMerged(term_lower_id)  # Pre-merged to base_frame
         lower_J_constraint = Constraint()  # Artificial constraint for J to model only selected transitions
         upper_J_constraint = Constraint()  # Artificial constraint for J to model only selected transitions
         ju = ApplyConstraint(Triangular(Lu, S), upper_J_constraint)

--- a/solrat/atom_model/multi_term_atom_model/radiative_transfer_equations.py
+++ b/solrat/atom_model/multi_term_atom_model/radiative_transfer_equations.py
@@ -21,10 +21,10 @@ from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.object.radiative_transfer_coefficients import RadiativeTransferCoefficients
 from solrat.atom_model.shared.object.rotations import T_K_Q_double_rotation_all_stokes, WignerD
 from solrat.atom_model.shared.utility.constants import c_cm_sm1, h_erg_s, sqrt_pi
-from solrat.atom_model.shared.utility.functions import energy_cmm1_to_frequency_hz
+from solrat.atom_model.shared.utility.functions import energy_cmm1_to_frequency_sm1
 from solrat.atom_model.shared.utility.voigt_profile import voigt
 from solrat.atom_model.shared.utility.wigner_3j_6j_9j import wigner_3j, wigner_6j
-from solrat.engine.functions.decorators import log_method
+from solrat.engine.functions.decorators import VERBOSE, log_method
 from solrat.engine.functions.general import m1p, n_proj
 from solrat.engine.generators.merge_frame import Frame, SumLimits
 from solrat.engine.generators.merge_loopers import (
@@ -93,6 +93,7 @@ class MultiTermAtomRTE(BaseRTE):
         r"""
         Constructor from the model config.
         """
+        logging.info("Constructing MultiTermAtomRTE instance")
 
         return cls(
             level_registry=config.level_registry,
@@ -260,6 +261,7 @@ class MultiTermAtomRTE(BaseRTE):
         """
         return 2 * h_erg_s * nu**3 / c_cm_sm1**2 * np.real(eta_s)
 
+    @log_method
     def create_base_frame(self) -> pd.DataFrame:
         r"""
         Generate a base frame, listing all transitions. This frame will be used as a starting point to determine
@@ -274,9 +276,10 @@ class MultiTermAtomRTE(BaseRTE):
 
             logging.debug(f"Processing {term_upper.term_id} -> {term_lower.term_id}")
             if self.cutoff_condition(term_upper=term_upper, term_lower=term_lower, nu=self.nu):
-                logging.info(
+                logging.log(
+                    VERBOSE,
                     f"Cutting off the transition {term_upper.term_id} -> {term_lower.term_id} "
-                    f"because it does not contribute to the specified frequency range"
+                    f"because it does not contribute to the specified frequency range",
                 )
                 continue
 
@@ -312,6 +315,8 @@ class MultiTermAtomRTE(BaseRTE):
 
         Reference: (LL04 7.47)
         """
+        logging.info("Calculating Radiative Transfer Coefficients")
+
         eta_rho_a = self.calculate_eta_rho_a(
             angles=angles,
             rho=rho,
@@ -360,7 +365,7 @@ class MultiTermAtomRTE(BaseRTE):
 
     def phi(self, term_upper_id, ju, Mu, term_lower_id, jl, Ml, atmosphere_parameters):
         return self._phi(
-            nui=energy_cmm1_to_frequency_hz(
+            nui=energy_cmm1_to_frequency_sm1(
                 self.paschen_back.eigenvalue(
                     term_id=term_upper_id,
                     j=ju,
@@ -385,11 +390,11 @@ class MultiTermAtomRTE(BaseRTE):
         Check the cut-off condition. If a transition is way outside the spectral region of interest,
         it does not contribute to RTE (due to the phi profile).
         """
-        nuimax = energy_cmm1_to_frequency_hz(term_upper.get_max_energy_cmm1() - term_lower.get_min_energy_cmm1())
-        nuimin = energy_cmm1_to_frequency_hz(term_upper.get_min_energy_cmm1() - term_lower.get_max_energy_cmm1())
+        nuimax = energy_cmm1_to_frequency_sm1(term_upper.get_max_energy_cmm1() - term_lower.get_min_energy_cmm1())
+        nuimin = energy_cmm1_to_frequency_sm1(term_upper.get_min_energy_cmm1() - term_lower.get_max_energy_cmm1())
         cutoff = self.delta_nu_cutoff
         if min(nu) > nuimax + cutoff or max(nu) < nuimin - cutoff:
-            logging.info(f"Cutoff condition: nui=[{nuimin}...{nuimax}], nu=[{min(nu)}...{max(nu)}]")
+            logging.log(VERBOSE, f"Cutoff condition: nui=[{nuimin}...{nuimax}], nu=[{min(nu)}...{max(nu)}]")
             return True
         return False
 

--- a/solrat/atom_model/multi_term_atom_model/statistical_equilibrium_equations.py
+++ b/solrat/atom_model/multi_term_atom_model/statistical_equilibrium_equations.py
@@ -1,3 +1,5 @@
+import logging
+
 try:
     from typing import Self  # Python 3.11+
 except ImportError:
@@ -21,7 +23,7 @@ from solrat.atom_model.multi_term_atom_model.object.rho_matrix_builder import (
     construct_coherence_id_from_term_id,
 )
 from solrat.atom_model.multi_term_atom_model.object.transition_registry import TransitionRegistry
-from solrat.atom_model.shared.utility.functions import energy_cmm1_to_frequency_hz
+from solrat.atom_model.shared.utility.functions import energy_cmm1_to_frequency_sm1
 from solrat.atom_model.shared.utility.wigner_3j_6j_9j import wigner_3j, wigner_6j, wigner_9j
 from solrat.engine.functions.decorators import log_method
 from solrat.engine.functions.general import delta, m1p, n_proj
@@ -82,6 +84,7 @@ class MultiTermAtomSEE(BaseSEE):
         r"""
         Constructor from the model config.
         """
+        logging.info("Constructing MultiTermAtomSEE instance")
 
         if config.precomputed_data is None:
             return cls(
@@ -177,6 +180,7 @@ class MultiTermAtomSEE(BaseSEE):
             radiation_tensor=radiation_tensor_in_magnetic_frame,
         )
 
+    @log_method
     def precompute_coherence_decay(self, term: Term, K: int, Q: int, J: float, Jʹ: float):
         r"""
         Precompute all coherence decay :math:`N` kernel parameters :math:`n_0` and :math:`n_1`:
@@ -213,6 +217,7 @@ class MultiTermAtomSEE(BaseSEE):
         df["coefficient"] = -2 * pi * 1j * (df.n_0 + df.n_1 * atmosphere_parameters.nu_larmor)
         self.matrix_builder.add_coefficient_from_df(df)
 
+    @log_method
     def precompute_absorption(self, term: Term, K: int, Q: int, J: float, Jʹ: float):
         r"""
         Precompute all Absorption parameters :math:`t_{a1}`:
@@ -264,6 +269,7 @@ class MultiTermAtomSEE(BaseSEE):
         df["coefficient"] = df.t_a_1 * df.radiation_tensor
         self.matrix_builder.add_coefficient_from_df(df)
 
+    @log_method
     def precompute_emission(self, term: Term, K: int, Q: int, J: float, Jʹ: float):
         r"""
         Precompute all Emission parameters coefficient, :math:`t_{s1}`:
@@ -331,6 +337,7 @@ class MultiTermAtomSEE(BaseSEE):
         df_s["coefficient"] = df_s.t_s_1 * df_s.radiation_tensor
         self.matrix_builder.add_coefficient_from_df(df_s)
 
+    @log_method
     def precompute_relaxation(self, term: Term, K: int, Q: int, J: float, Jʹ: float):
         r"""
         Precompute all relaxation parameters :math:`r_{a1}, r_{e0}, r_{s1}`:
@@ -411,6 +418,7 @@ class MultiTermAtomSEE(BaseSEE):
         df_s["coefficient"] = -df_s.r_s_1 * df_s.radiation_tensor
         self.matrix_builder.add_coefficient_from_df(df_s)
 
+    @log_method
     def precompute_r_a(
         self, term: Term, K: int, Q: int, J: float, Jʹ: float, Kʹ: int, Qʹ: int, Jʹʹ: float, Jʹʹʹ: float
     ):
@@ -483,6 +491,7 @@ class MultiTermAtomSEE(BaseSEE):
 
         return dfs
 
+    @log_method
     def precompute_r_e(
         self, term: Term, K: int, Q: int, J: float, Jʹ: float, Kʹ: int, Qʹ: int, Jʹʹ: float, Jʹʹʹ: float
     ):
@@ -517,6 +526,7 @@ class MultiTermAtomSEE(BaseSEE):
             )
         return dfs
 
+    @log_method
     def precompute_r_s(
         self, term: Term, K: int, Q: int, J: float, Jʹ: float, Kʹ: int, Qʹ: int, Jʹʹ: float, Jʹʹʹ: float
     ):
@@ -608,6 +618,7 @@ class MultiTermAtomSEE(BaseSEE):
         )
         return result
 
+    @log_method
     def precompute_n(self, term: Term, K: int, Q: int, J: float, Jʹ: float, Kʹ: int, Qʹ: int, Jʹʹ: float, Jʹʹʹ: float):
         r"""
         Precompute coherence relaxation parameters :math:`n_0, n_1`:
@@ -621,7 +632,7 @@ class MultiTermAtomSEE(BaseSEE):
 
         level = self.level_registry.get_level(term=term, J=J)
         level_prime = self.level_registry.get_level(term=term, J=Jʹ)
-        nu = energy_cmm1_to_frequency_hz(level.energy_cmm1 - level_prime.energy_cmm1)
+        nu = energy_cmm1_to_frequency_sm1(level.energy_cmm1 - level_prime.energy_cmm1)
 
         n_0 = delta(K, Kʹ) * delta(Q, Qʹ) * delta(J, Jʹʹ) * delta(Jʹ, Jʹʹʹ) * nu
 
@@ -653,6 +664,7 @@ class MultiTermAtomSEE(BaseSEE):
         )
         return df
 
+    @log_method
     def precompute_t_a(
         self,
         term: Term,
@@ -713,6 +725,7 @@ class MultiTermAtomSEE(BaseSEE):
 
         return dfs
 
+    @log_method
     def precompute_t_e(
         self,
         term: Term,
@@ -769,6 +782,7 @@ class MultiTermAtomSEE(BaseSEE):
             )
         ]
 
+    @log_method
     def precompute_t_s(
         self,
         term: Term,
@@ -854,6 +868,7 @@ class MultiTermAtomSEE(BaseSEE):
 
         This system generally behaves well enough for linalg.solve to succeed, but pinv is more robust.
         """
+        logging.info("Solving Statistical Equilibrium Equations")
         # sol = np.linalg.solve(
         #     self.matrix_builder.rho_matrix[:, 1:, 1:],
         #     -self.matrix_builder.rho_matrix[:, 1:, 0:1],

--- a/solrat/atom_model/multi_term_atom_model/statistical_equilibrium_equations.py
+++ b/solrat/atom_model/multi_term_atom_model/statistical_equilibrium_equations.py
@@ -180,7 +180,6 @@ class MultiTermAtomSEE(BaseSEE):
             radiation_tensor=radiation_tensor_in_magnetic_frame,
         )
 
-    @log_method
     def precompute_coherence_decay(self, term: Term, K: int, Q: int, J: float, Jʹ: float):
         r"""
         Precompute all coherence decay :math:`N` kernel parameters :math:`n_0` and :math:`n_1`:
@@ -217,7 +216,6 @@ class MultiTermAtomSEE(BaseSEE):
         df["coefficient"] = -2 * pi * 1j * (df.n_0 + df.n_1 * atmosphere_parameters.nu_larmor)
         self.matrix_builder.add_coefficient_from_df(df)
 
-    @log_method
     def precompute_absorption(self, term: Term, K: int, Q: int, J: float, Jʹ: float):
         r"""
         Precompute all Absorption parameters :math:`t_{a1}`:
@@ -269,7 +267,6 @@ class MultiTermAtomSEE(BaseSEE):
         df["coefficient"] = df.t_a_1 * df.radiation_tensor
         self.matrix_builder.add_coefficient_from_df(df)
 
-    @log_method
     def precompute_emission(self, term: Term, K: int, Q: int, J: float, Jʹ: float):
         r"""
         Precompute all Emission parameters coefficient, :math:`t_{s1}`:
@@ -337,7 +334,6 @@ class MultiTermAtomSEE(BaseSEE):
         df_s["coefficient"] = df_s.t_s_1 * df_s.radiation_tensor
         self.matrix_builder.add_coefficient_from_df(df_s)
 
-    @log_method
     def precompute_relaxation(self, term: Term, K: int, Q: int, J: float, Jʹ: float):
         r"""
         Precompute all relaxation parameters :math:`r_{a1}, r_{e0}, r_{s1}`:
@@ -418,7 +414,6 @@ class MultiTermAtomSEE(BaseSEE):
         df_s["coefficient"] = -df_s.r_s_1 * df_s.radiation_tensor
         self.matrix_builder.add_coefficient_from_df(df_s)
 
-    @log_method
     def precompute_r_a(
         self, term: Term, K: int, Q: int, J: float, Jʹ: float, Kʹ: int, Qʹ: int, Jʹʹ: float, Jʹʹʹ: float
     ):
@@ -491,7 +486,6 @@ class MultiTermAtomSEE(BaseSEE):
 
         return dfs
 
-    @log_method
     def precompute_r_e(
         self, term: Term, K: int, Q: int, J: float, Jʹ: float, Kʹ: int, Qʹ: int, Jʹʹ: float, Jʹʹʹ: float
     ):
@@ -526,7 +520,6 @@ class MultiTermAtomSEE(BaseSEE):
             )
         return dfs
 
-    @log_method
     def precompute_r_s(
         self, term: Term, K: int, Q: int, J: float, Jʹ: float, Kʹ: int, Qʹ: int, Jʹʹ: float, Jʹʹʹ: float
     ):
@@ -618,7 +611,6 @@ class MultiTermAtomSEE(BaseSEE):
         )
         return result
 
-    @log_method
     def precompute_n(self, term: Term, K: int, Q: int, J: float, Jʹ: float, Kʹ: int, Qʹ: int, Jʹʹ: float, Jʹʹʹ: float):
         r"""
         Precompute coherence relaxation parameters :math:`n_0, n_1`:
@@ -664,7 +656,6 @@ class MultiTermAtomSEE(BaseSEE):
         )
         return df
 
-    @log_method
     def precompute_t_a(
         self,
         term: Term,
@@ -725,7 +716,6 @@ class MultiTermAtomSEE(BaseSEE):
 
         return dfs
 
-    @log_method
     def precompute_t_e(
         self,
         term: Term,
@@ -782,7 +772,6 @@ class MultiTermAtomSEE(BaseSEE):
             )
         ]
 
-    @log_method
     def precompute_t_s(
         self,
         term: Term,

--- a/solrat/atom_model/multi_term_atom_model/utility/einstein_coefficients.py
+++ b/solrat/atom_model/multi_term_atom_model/utility/einstein_coefficients.py
@@ -1,6 +1,8 @@
 from solrat.atom_model.shared.utility.constants import c_cm_sm1, h_erg_s
+from solrat.engine.functions.decorators import log_function
 
 
+@log_function
 def b_ul_from_a_ul_multi_term_atom(a_ul_sm1: float, nu_ul: float) -> float:
     r"""
     Transform from :math:`A_{ul}` [s^-1] to :math:`B_{ul}` [cm^2/erg/s]
@@ -11,6 +13,7 @@ def b_ul_from_a_ul_multi_term_atom(a_ul_sm1: float, nu_ul: float) -> float:
     return a_ul_sm1 / factor
 
 
+@log_function
 def b_lu_from_b_ul_multi_term_atom(b_ul: float, Lu: float, Ll: float) -> float:
     r"""
     Transform from :math:`B_{lu}` [cm^2/erg/s] to `B_{ul}` [cm^2/erg/s]

--- a/solrat/atom_model/multi_term_atom_model/utility/paschen_back.py
+++ b/solrat/atom_model/multi_term_atom_model/utility/paschen_back.py
@@ -1,9 +1,10 @@
+from functools import lru_cache
 from typing import Tuple, Union
 
 import numpy as np
 from numpy import sqrt
 
-from solrat.atom_model.multi_term_atom_model.object.level_registry import Term
+from solrat.atom_model.multi_term_atom_model.object.level_registry import LevelRegistry, Term
 from solrat.atom_model.shared.utility.constants import c_cm_sm1, h_erg_s, mu0_erg_gaussm1
 from solrat.engine.functions.decorators import log_function_experimental
 from solrat.engine.functions.general import half_int_to_str
@@ -86,6 +87,7 @@ def get_artificial_S_scale_from_term_g(g, J, L, S):
     return (g - 1) / alpha
 
 
+@lru_cache(maxsize=100)
 def calculate_paschen_back(
     term: Term, magnetic_field_gauss: float
 ) -> Tuple[PaschenBackEigenvalues, PaschenBackCoefficients]:
@@ -165,3 +167,20 @@ def calculate_paschen_back(
                 coefficients.set(j=J_max - j, M=M, J=J_max - j1, value=eig_vectors[j1, j])
 
     return eigenvalues, coefficients
+
+
+class PaschenBack:
+    def __init__(self, level_registry: LevelRegistry):
+        self.level_registry = level_registry
+
+    def eigenvalue(self, term_id, j, M, magnetic_field_gauss):
+        pb_eigenvalues, pb_eigenvectors = calculate_paschen_back(
+            term=self.level_registry.terms[term_id], magnetic_field_gauss=magnetic_field_gauss
+        )
+        return pb_eigenvalues(j=j, M=M)
+
+    def eigenvector(self, term_id, j, J, M, magnetic_field_gauss):
+        pb_eigenvalues, pb_eigenvectors = calculate_paschen_back(
+            term=self.level_registry.terms[term_id], magnetic_field_gauss=magnetic_field_gauss
+        )
+        return pb_eigenvectors(j=j, J=J, M=M)

--- a/solrat/atom_model/multi_term_atom_model_legacy/radiative_transfer_equations_legacy.py
+++ b/solrat/atom_model/multi_term_atom_model_legacy/radiative_transfer_equations_legacy.py
@@ -19,7 +19,7 @@ from solrat.atom_model.shared.object.angles import Angles
 from solrat.atom_model.shared.object.radiative_transfer_coefficients import RadiativeTransferCoefficients
 from solrat.atom_model.shared.object.rotations import T_K_Q_double_rotation, WignerD
 from solrat.atom_model.shared.utility.constants import c_cm_sm1, h_erg_s, sqrt_pi
-from solrat.atom_model.shared.utility.functions import energy_cmm1_to_frequency_hz
+from solrat.atom_model.shared.utility.functions import energy_cmm1_to_frequency_sm1
 from solrat.atom_model.shared.utility.voigt_profile import voigt
 from solrat.atom_model.shared.utility.wigner_3j_6j_9j import wigner_3j, wigner_6j
 from solrat.engine.functions.decorators import log_method
@@ -62,6 +62,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
         r"""
         Constructor from the model config.
         """
+        logging.info("Constructing MultiTermAtomRTELegacy instance")
 
         return cls(
             transition_registry=config.transition_registry,
@@ -84,7 +85,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
         """
         If the transition is far away from the requested frequency range, it does not contribute to RTE.
         """
-        nui = energy_cmm1_to_frequency_hz(term_upper.get_mean_energy_cmm1() - term_lower.get_mean_energy_cmm1())
+        nui = energy_cmm1_to_frequency_sm1(term_upper.get_mean_energy_cmm1() - term_lower.get_mean_energy_cmm1())
         cutoff = (
             self.maximum_delta_v_thermal_units_cutoff * nui * atmosphere_parameters.delta_v_thermal_cm_sm1 / c_cm_sm1
         )
@@ -92,6 +93,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
             return True
         return False
 
+    @log_method
     def eta_a(
         self,
         rho: Rho,
@@ -154,7 +156,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
                             lambda: T_K_Q_double_rotation(K, Q, stokes_component_index, D_inverse_omega, D_magnetic),
                             lambda: rho(term_id=term_lower.term_id, K=Kl, Q=Ql, J=Jʹʹl, Jʹ=Jʹl),
                             lambda: self.phi(
-                                nui=energy_cmm1_to_frequency_hz(
+                                nui=energy_cmm1_to_frequency_sm1(
                                     upper_pb_eigenvalues(j=ju, M=Mu) - lower_pb_eigenvalues(j=jl, M=Ml),
                                 ),
                                 nu=self.nu,
@@ -184,6 +186,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
             )
         return result
 
+    @log_method
     def eta_s(
         self,
         rho: Rho,
@@ -255,7 +258,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
                             ),
                             lambda: rho(term_id=term_upper.term_id, K=Ku, Q=Qu, J=Jʹu, Jʹ=Jʹʹu),
                             lambda: self.phi(
-                                nui=energy_cmm1_to_frequency_hz(
+                                nui=energy_cmm1_to_frequency_sm1(
                                     upper_pb_eigenvalues(j=ju, M=Mu) - lower_pb_eigenvalues(j=jl, M=Ml),
                                 ),
                                 nu=self.nu,
@@ -284,6 +287,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
             )
         return result
 
+    @log_method
     def rho_a(
         self,
         rho: Rho,
@@ -352,7 +356,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
                             ),
                             lambda: rho(term_id=term_lower.term_id, K=Kl, Q=Ql, J=Jʹʹl, Jʹ=Jʹl),
                             lambda: self.phi(
-                                nui=energy_cmm1_to_frequency_hz(
+                                nui=energy_cmm1_to_frequency_sm1(
                                     upper_pb_eigenvalues(j=ju, M=Mu) - lower_pb_eigenvalues(j=jl, M=Ml),
                                 ),
                                 nu=self.nu,
@@ -382,6 +386,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
             )
         return result
 
+    @log_method
     def rho_s(
         self,
         rho: Rho,
@@ -447,7 +452,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
                             lambda: T_K_Q_double_rotation(K, Q, stokes_component_index, D_inverse_omega, D_magnetic),
                             lambda: rho(term_id=term_upper.term_id, K=Ku, Q=Qu, J=Jʹu, Jʹ=Jʹʹu),
                             lambda: self.phi(
-                                nui=energy_cmm1_to_frequency_hz(
+                                nui=energy_cmm1_to_frequency_sm1(
                                     upper_pb_eigenvalues(j=ju, M=Mu) - lower_pb_eigenvalues(j=jl, M=Ml),
                                 ),
                                 nu=self.nu,
@@ -489,6 +494,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
     Returning complex values for eta_rho gives 2x performance benefit.
     """
 
+    @log_method
     def eta_rho_a(
         self,
         rho: Rho,
@@ -550,7 +556,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
                         lambda: T_K_Q_double_rotation(K, Q, stokes_component_index, D_inverse_omega, D_magnetic),
                         lambda: rho(term_id=term_lower.term_id, K=Kl, Q=Ql, J=Jʹʹl, Jʹ=Jʹl),
                         lambda: self.phi(
-                            nui=energy_cmm1_to_frequency_hz(
+                            nui=energy_cmm1_to_frequency_sm1(
                                 upper_pb_eigenvalues(j=ju, M=Mu) - lower_pb_eigenvalues(j=jl, M=Ml),
                             ),
                             nu=self.nu,
@@ -579,6 +585,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
             )
         return result
 
+    @log_method
     def eta_rho_s(
         self,
         rho: Rho,
@@ -643,7 +650,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
                         lambda: T_K_Q_double_rotation(K, Q, stokes_component_index, D_inverse_omega, D_magnetic),
                         lambda: rho(term_id=term_upper.term_id, K=Ku, Q=Qu, J=Jʹu, Jʹ=Jʹʹu),
                         lambda: self.phi(
-                            nui=energy_cmm1_to_frequency_hz(
+                            nui=energy_cmm1_to_frequency_sm1(
                                 upper_pb_eigenvalues(j=ju, M=Mu) - lower_pb_eigenvalues(j=jl, M=Ml),
                             ),
                             nu=self.nu,
@@ -675,6 +682,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
     The following are some analytical expressions under further assumptions for validation.
     """
 
+    @log_method
     def eta_a_no_field_no_fine_structure(
         self,
         rho: Rho,
@@ -724,7 +732,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
                             lambda: T_K_Q_double_rotation(K, Q, stokes_component_index, D_inverse_omega, D_magnetic),
                             lambda: rho(term_id=term_lower.term_id, K=K, Q=Q, J=Jl, Jʹ=Jʹl),
                             lambda: self.phi(
-                                nui=energy_cmm1_to_frequency_hz(
+                                nui=energy_cmm1_to_frequency_sm1(
                                     term_upper.get_mean_energy_cmm1() - term_lower.get_mean_energy_cmm1()
                                 ),
                                 nu=self.nu,
@@ -742,6 +750,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
             )
         return result
 
+    @log_method
     def eta_s_no_field_no_fine_structure(
         self,
         rho: Rho,
@@ -795,7 +804,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
                             lambda: T_K_Q_double_rotation(K, Q, stokes_component_index, D_inverse_omega, D_magnetic),
                             lambda: rho(term_id=term_upper.term_id, K=K, Q=Q, J=Jʹu, Jʹ=Ju),
                             lambda: self.phi(
-                                nui=energy_cmm1_to_frequency_hz(
+                                nui=energy_cmm1_to_frequency_sm1(
                                     term_upper.get_mean_energy_cmm1() - term_lower.get_mean_energy_cmm1()
                                 ),
                                 nu=self.nu,
@@ -812,6 +821,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
             )
         return result
 
+    @log_method
     def rho_a_no_field_no_fine_structure(
         self,
         rho: Rho,
@@ -861,7 +871,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
                             lambda: T_K_Q_double_rotation(K, Q, stokes_component_index, D_inverse_omega, D_magnetic),
                             lambda: rho(term_id=term_lower.term_id, K=K, Q=Q, J=Jl, Jʹ=Jʹl),
                             lambda: self.phi(
-                                nui=energy_cmm1_to_frequency_hz(
+                                nui=energy_cmm1_to_frequency_sm1(
                                     term_upper.get_mean_energy_cmm1() - term_lower.get_mean_energy_cmm1()
                                 ),
                                 nu=self.nu,
@@ -879,6 +889,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
             )
         return result
 
+    @log_method
     def rho_s_no_field_no_fine_structure(
         self,
         rho: Rho,
@@ -932,7 +943,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
                             lambda: T_K_Q_double_rotation(K, Q, stokes_component_index, D_inverse_omega, D_magnetic),
                             lambda: rho(term_id=term_upper.term_id, K=K, Q=Q, J=Jʹu, Jʹ=Ju),
                             lambda: self.phi(
-                                nui=energy_cmm1_to_frequency_hz(
+                                nui=energy_cmm1_to_frequency_sm1(
                                     term_upper.get_mean_energy_cmm1() - term_lower.get_mean_energy_cmm1()
                                 ),
                                 nu=self.nu,
@@ -949,6 +960,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
             )
         return result
 
+    @log_method
     def eta_s_no_field(
         self,
         rho: Rho,
@@ -999,7 +1011,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
                             lambda: 0.5
                             * (
                                 self.phi(
-                                    nui=energy_cmm1_to_frequency_hz(
+                                    nui=energy_cmm1_to_frequency_sm1(
                                         term_upper.get_level(J=Ju).energy_cmm1 - term_lower.get_level(J=Jl).energy_cmm1,
                                     ),
                                     nu=self.nu,
@@ -1007,7 +1019,7 @@ class MultiTermAtomRTELegacy(BaseRTE):
                                 )
                                 + np.conjugate(
                                     self.phi(
-                                        nui=energy_cmm1_to_frequency_hz(
+                                        nui=energy_cmm1_to_frequency_sm1(
                                             term_upper.get_level(J=Jʹu).energy_cmm1
                                             - term_lower.get_level(J=Jl).energy_cmm1,
                                         ),

--- a/solrat/atom_model/multi_term_atom_model_legacy/statistical_equilibrium_equations_legacy.py
+++ b/solrat/atom_model/multi_term_atom_model_legacy/statistical_equilibrium_equations_legacy.py
@@ -16,7 +16,7 @@ from solrat.atom_model.multi_term_atom_model.object.multi_term_atom_config impor
 from solrat.atom_model.multi_term_atom_model.object.radiation_tensor import RadiationTensor
 from solrat.atom_model.multi_term_atom_model.object.rho_matrix_builder import Rho, RhoMatrixBuilder
 from solrat.atom_model.multi_term_atom_model.object.transition_registry import TransitionRegistry
-from solrat.atom_model.shared.utility.functions import energy_cmm1_to_frequency_hz
+from solrat.atom_model.shared.utility.functions import energy_cmm1_to_frequency_sm1
 from solrat.atom_model.shared.utility.wigner_3j_6j_9j import wigner_3j, wigner_6j, wigner_9j
 from solrat.engine.functions.decorators import log_method
 from solrat.engine.functions.general import delta, m1p, n_proj
@@ -53,12 +53,15 @@ class MultiTermAtomSEELegacy(BaseSEE):
         r"""
         Constructor from the model config.
         """
+        logging.info("Constructing MultiTermAtomSEELegacy instance")
+
         return cls(
             level_registry=config.level_registry,
             transition_registry=config.transition_registry,
             disable_r_s=config.disable_r_s,
         )
 
+    @log_method
     def fill_all_equations(
         self, atmosphere_parameters: AtmosphereParameters, radiation_tensor_in_magnetic_frame: RadiationTensor
     ) -> None:
@@ -109,6 +112,7 @@ class MultiTermAtomSEELegacy(BaseSEE):
                     radiation_tensor=radiation_tensor_in_magnetic_frame,
                 )
 
+    @log_method
     def add_coherence_decay(
         self,
         term: Term,
@@ -141,6 +145,7 @@ class MultiTermAtomSEELegacy(BaseSEE):
             )
             self.matrix_builder.add_coefficient(term=term, K=Kʹ, Q=Qʹ, J=Jʹʹ, Jʹ=Jʹʹʹ, coefficient=-2 * pi * 1j * n)
 
+    @log_method
     def add_absorption(
         self,
         term: Term,
@@ -179,6 +184,7 @@ class MultiTermAtomSEELegacy(BaseSEE):
                 )
                 self.matrix_builder.add_coefficient(term=term_lower, K=Kl, Q=Ql, J=Jl, Jʹ=Jʹl, coefficient=t_a)
 
+    @log_method
     def add_emission(
         self,
         term: Term,
@@ -229,6 +235,7 @@ class MultiTermAtomSEELegacy(BaseSEE):
                 )
                 self.matrix_builder.add_coefficient(term=term_upper, K=Ku, Q=Qu, J=Ju, Jʹ=Jʹu, coefficient=t_e + t_s)
 
+    @log_method
     def add_relaxation(
         self,
         term: Term,
@@ -288,6 +295,7 @@ class MultiTermAtomSEELegacy(BaseSEE):
                 )
             self.matrix_builder.add_coefficient(term=term, K=Kʹ, Q=Qʹ, J=Jʹʹ, Jʹ=Jʹʹʹ, coefficient=-(r_a + r_e + r_s))
 
+    @log_method
     def r_a(
         self,
         term: Term,
@@ -342,6 +350,7 @@ class MultiTermAtomSEELegacy(BaseSEE):
             )
         return result
 
+    @log_method
     def r_e(
         self,
         term: Term,
@@ -362,6 +371,7 @@ class MultiTermAtomSEELegacy(BaseSEE):
             result += delta(K, Kʹ) * delta(Q, Qʹ) * delta(J, Jʹʹ) * delta(Jʹ, Jʹʹʹ) * transition.einstein_a_ul
         return result
 
+    @log_method
     def r_s(
         self,
         term: Term,
@@ -433,6 +443,7 @@ class MultiTermAtomSEELegacy(BaseSEE):
         )
         return result
 
+    @log_method
     def n(
         self,
         term: Term,
@@ -454,7 +465,7 @@ class MultiTermAtomSEELegacy(BaseSEE):
 
         level = self.level_registry.get_level(term=term, J=J)
         level_prime = self.level_registry.get_level(term=term, J=Jʹ)
-        nu = energy_cmm1_to_frequency_hz(level.energy_cmm1 - level_prime.energy_cmm1)
+        nu = energy_cmm1_to_frequency_sm1(level.energy_cmm1 - level_prime.energy_cmm1)
 
         result = delta(K, Kʹ) * delta(Q, Qʹ) * delta(J, Jʹʹ) * delta(Jʹ, Jʹʹʹ) * nu
 
@@ -471,6 +482,7 @@ class MultiTermAtomSEELegacy(BaseSEE):
         )
         return result
 
+    @log_method
     def t_a(
         self,
         term: Term,
@@ -510,6 +522,7 @@ class MultiTermAtomSEELegacy(BaseSEE):
             Qr=INTERSECTION(PROJECTION("Kr"), VALUE(Ql - Q)),
         )
 
+    @log_method
     def t_e(
         self,
         term: Term,
@@ -609,6 +622,8 @@ class MultiTermAtomSEELegacy(BaseSEE):
 
         This system generally behaves well enough for linalg.solve to succeed, but pinv is more robust.
         """
+        logging.info("Solving Statistical Equilibrium Equations")
+
         # sol = np.linalg.solve(
         #     self.matrix_builder.rho_matrix[:, 1:, 1:],
         #     -self.matrix_builder.rho_matrix[:, 1:, 0:1],

--- a/solrat/atom_model/multi_term_atom_model_legacy/statistical_equilibrium_equations_legacy.py
+++ b/solrat/atom_model/multi_term_atom_model_legacy/statistical_equilibrium_equations_legacy.py
@@ -112,7 +112,6 @@ class MultiTermAtomSEELegacy(BaseSEE):
                     radiation_tensor=radiation_tensor_in_magnetic_frame,
                 )
 
-    @log_method
     def add_coherence_decay(
         self,
         term: Term,
@@ -145,7 +144,6 @@ class MultiTermAtomSEELegacy(BaseSEE):
             )
             self.matrix_builder.add_coefficient(term=term, K=Kʹ, Q=Qʹ, J=Jʹʹ, Jʹ=Jʹʹʹ, coefficient=-2 * pi * 1j * n)
 
-    @log_method
     def add_absorption(
         self,
         term: Term,
@@ -184,7 +182,6 @@ class MultiTermAtomSEELegacy(BaseSEE):
                 )
                 self.matrix_builder.add_coefficient(term=term_lower, K=Kl, Q=Ql, J=Jl, Jʹ=Jʹl, coefficient=t_a)
 
-    @log_method
     def add_emission(
         self,
         term: Term,
@@ -235,7 +232,6 @@ class MultiTermAtomSEELegacy(BaseSEE):
                 )
                 self.matrix_builder.add_coefficient(term=term_upper, K=Ku, Q=Qu, J=Ju, Jʹ=Jʹu, coefficient=t_e + t_s)
 
-    @log_method
     def add_relaxation(
         self,
         term: Term,
@@ -295,7 +291,6 @@ class MultiTermAtomSEELegacy(BaseSEE):
                 )
             self.matrix_builder.add_coefficient(term=term, K=Kʹ, Q=Qʹ, J=Jʹʹ, Jʹ=Jʹʹʹ, coefficient=-(r_a + r_e + r_s))
 
-    @log_method
     def r_a(
         self,
         term: Term,
@@ -350,7 +345,6 @@ class MultiTermAtomSEELegacy(BaseSEE):
             )
         return result
 
-    @log_method
     def r_e(
         self,
         term: Term,
@@ -371,7 +365,6 @@ class MultiTermAtomSEELegacy(BaseSEE):
             result += delta(K, Kʹ) * delta(Q, Qʹ) * delta(J, Jʹʹ) * delta(Jʹ, Jʹʹʹ) * transition.einstein_a_ul
         return result
 
-    @log_method
     def r_s(
         self,
         term: Term,
@@ -443,7 +436,6 @@ class MultiTermAtomSEELegacy(BaseSEE):
         )
         return result
 
-    @log_method
     def n(
         self,
         term: Term,
@@ -482,7 +474,6 @@ class MultiTermAtomSEELegacy(BaseSEE):
         )
         return result
 
-    @log_method
     def t_a(
         self,
         term: Term,
@@ -522,7 +513,6 @@ class MultiTermAtomSEELegacy(BaseSEE):
             Qr=INTERSECTION(PROJECTION("Kr"), VALUE(Ql - Q)),
         )
 
-    @log_method
     def t_e(
         self,
         term: Term,

--- a/solrat/atom_model/multi_term_atom_model_lte/statistical_equilibrium_equations.py
+++ b/solrat/atom_model/multi_term_atom_model_lte/statistical_equilibrium_equations.py
@@ -1,3 +1,5 @@
+import logging
+
 try:
     from typing import Self  # Python 3.11+
 except ImportError:
@@ -45,6 +47,7 @@ class MultiTermAtomSEELTE(BaseSEE):
         r"""
         Constructor from the model config.
         """
+        logging.info("Constructing MultiTermAtomSEELTE instance")
         return cls(
             level_registry=config.level_registry,
         )
@@ -80,6 +83,7 @@ class MultiTermAtomSEELTE(BaseSEE):
 
         Reference: (LL04 3.108) (LL04 10.118)
         """
+        logging.info("Applying LTE Statistical Equilibrium Equations solution")
 
         T = self.atmosphere_parameters.temperature_K
 

--- a/solrat/atom_model/shared/common_api/constant_property_slab.py
+++ b/solrat/atom_model/shared/common_api/constant_property_slab.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Union
 
 import numpy as np
@@ -87,6 +88,7 @@ class ConstantPropertySlabAtmosphere:
 
         Reference: modified (9.36)
         """
+        logging.info("Processing a single slab...")
 
         self.see.fill_all_equations(
             atmosphere_parameters=self.atmosphere_parameters,
@@ -125,7 +127,9 @@ class ConstantPropertySlabAtmosphere:
         K_tau_line[:, 1, 1] += 1 / eta_LC
         K_tau_line[:, 2, 2] += 1 / eta_LC
         K_tau_line[:, 3, 3] += 1 / eta_LC
-        epsilon_tau_line[:, 0] += get_planck_BP(nu_sm1=nu, T_K=self.atmosphere_parameters.temperature_K) / eta_LC
+        epsilon_tau_line[:, 0] += (
+            get_planck_BP(nu_sm1=nu, temperature_K=self.atmosphere_parameters.temperature_K) / eta_LC
+        )
 
         # DELO method:
         # Solve dStokes/dtau = K*(Stokes-S), where
@@ -141,6 +145,8 @@ class ConstantPropertySlabAtmosphere:
 
         expM = np.stack([expm(-K * self.line_delta_tau) for K in K_tau_line])
         stokes = S[:, :, np.newaxis] + np.einsum("nij,njk->nik", expM, stokes - S[:, :, np.newaxis])
+
+        logging.info("Completed processing a single slab")
 
         return Stokes(
             nu=nu,

--- a/solrat/atom_model/shared/common_api/multi_slab_atmosphere.py
+++ b/solrat/atom_model/shared/common_api/multi_slab_atmosphere.py
@@ -1,5 +1,6 @@
 from solrat.atom_model.shared.common_api.constant_property_slab import ConstantPropertySlabAtmosphere
 from solrat.atom_model.shared.object.stokes import Stokes
+from solrat.engine.functions.decorators import log_method
 
 
 class MultiSlabAtmosphere:
@@ -9,6 +10,7 @@ class MultiSlabAtmosphere:
         """
         self.slabs = slabs
 
+    @log_method
     def forward(self, initial_stokes: Stokes) -> Stokes:
         r"""
         Propagate radiation through slabs sequentially (one after another).

--- a/solrat/atom_model/shared/object/radiative_transfer_coefficients.py
+++ b/solrat/atom_model/shared/object/radiative_transfer_coefficients.py
@@ -157,7 +157,13 @@ class RadiativeTransferCoefficients:
         """
         Line-center eta, assuming a single spectral line
         """
-        return np.max(np.abs(np.real(self.eta_rho_aI - self.eta_rho_sI)))
+        scale = np.max(np.abs(np.real(self.eta_rho_aI - self.eta_rho_sI)))
+        if scale == 0:
+            raise ValueError(
+                "eta_tau_scale is zero: the spectral line has no opacity over the supplied frequency grid. "
+                "Check that the frequency grid is centered on the actual transition wavelength."
+            )
+        return scale
 
     def epsilon_z(self) -> np.ndarray:
         """

--- a/solrat/atom_model/shared/object/radiative_transfer_coefficients.py
+++ b/solrat/atom_model/shared/object/radiative_transfer_coefficients.py
@@ -2,6 +2,8 @@ from typing import Tuple
 
 import numpy as np
 
+from solrat.engine.functions.decorators import log_method
+
 
 class RadiativeTransferCoefficients:
     def __init__(
@@ -72,6 +74,7 @@ class RadiativeTransferCoefficients:
     def get_epsilon_V(self):
         return np.real(self.epsilonV)
 
+    @log_method
     def split_eta_rho(
         self,
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
@@ -88,6 +91,7 @@ class RadiativeTransferCoefficients:
         rhoV = np.imag(self.eta_rho_aV - self.eta_rho_sV)
         return etaI, etaQ, etaU, etaV, rhoQ, rhoU, rhoV
 
+    @log_method
     def K_z(self) -> np.ndarray:
         r"""
         RT matrix K related to the z-propagation equation:
@@ -134,6 +138,7 @@ class RadiativeTransferCoefficients:
         K[:, 3, 3] = etaI
         return K
 
+    @log_method
     def K_tau(self) -> np.ndarray:
         r"""
         RT matrix K related to the tau-propagation equation:
@@ -165,6 +170,7 @@ class RadiativeTransferCoefficients:
             )
         return scale
 
+    @log_method
     def epsilon_z(self) -> np.ndarray:
         """
         RT matrix emission coefficient epsilon related to the z-propagation equation: see the comments for K_z()
@@ -178,6 +184,7 @@ class RadiativeTransferCoefficients:
         epsilon[:, 3, 0] = self.epsilonV
         return epsilon
 
+    @log_method
     def epsilon_tau(self) -> np.ndarray:
         """
         RT matrix emission coefficient epsilon related to the tau-propagation equation: see the comments for K_tau()

--- a/solrat/atom_model/shared/object/rotations.py
+++ b/solrat/atom_model/shared/object/rotations.py
@@ -66,6 +66,23 @@ def T_K_Q_double_rotation(K, Q, stokes_component_index, D_inverse_omega: WignerD
     return result
 
 
+def T_K_Q_double_rotation_all_stokes(K, Q, D_inverse_omega: WignerD, D_magnetic: WignerD):
+    r"""
+    (5.159), (2.74), (5.122)
+    Two consecutive D rotations within T tensor.
+    """
+    result = np.array([[0], [0], [0], [0]], dtype=np.complex128)
+    for stokes_component_index in range(4):
+        for P, Qʹ in nested_loops(P=PROJECTION(K), Qʹ=PROJECTION(K)):
+            result[stokes_component_index][0] = result[stokes_component_index][0] + t_K_P(
+                K=K,
+                P=P,
+                stokes_component_index=stokes_component_index,
+            ) * D_inverse_omega(K=K, P=P, Q=Qʹ) * D_magnetic(K=K, P=Qʹ, Q=Q)
+
+    return result
+
+
 @lru_cache(maxsize=None)
 def T_K_Q(K, Q, stokes_component_index, chi, theta, gamma):
     r"""

--- a/solrat/atom_model/shared/object/rotations.py
+++ b/solrat/atom_model/shared/object/rotations.py
@@ -47,7 +47,6 @@ def t_K_P(K, P, stokes_component_index):
     )
 
 
-# @lru_cache(maxsize=None)
 def T_K_Q_double_rotation(K, Q, stokes_component_index, D_inverse_omega: WignerD, D_magnetic: WignerD):
     r"""
     (5.159), (2.74), (5.122)

--- a/solrat/atom_model/shared/object/stokes.py
+++ b/solrat/atom_model/shared/object/stokes.py
@@ -32,7 +32,7 @@ class Stokes:
         """
         return cls(
             nu=nu_sm1,
-            I=get_planck_BP(nu_sm1=nu_sm1, T_K=temperature_K),
+            I=get_planck_BP(nu_sm1=nu_sm1, temperature_K=temperature_K),
             Q=nu_sm1 * 0,
             U=nu_sm1 * 0,
             V=nu_sm1 * 0,

--- a/solrat/atom_model/shared/utility/functions.py
+++ b/solrat/atom_model/shared/utility/functions.py
@@ -2,15 +2,16 @@ import numpy as np
 from numpy import exp
 
 from solrat.atom_model.shared.utility.constants import c_cm_sm1, h_erg_s, kB_erg_Km1, mu0_erg_gaussm1
+from solrat.engine.functions.decorators import log_function
 from solrat.engine.functions.special import FloatOrNDArrayT
 
 
-def get_planck_BP(nu_sm1: FloatOrNDArrayT, T_K: float) -> FloatOrNDArrayT:
+def get_planck_BP(nu_sm1: FloatOrNDArrayT, temperature_K: float) -> FloatOrNDArrayT:
     """
     Planck function
     Reference: (below 5.40)
     """
-    return 2 * h_erg_s * nu_sm1**3 / c_cm_sm1**2 / (exp(h_erg_s * nu_sm1 / kB_erg_Km1 / T_K) - 1)
+    return 2 * h_erg_s * nu_sm1**3 / c_cm_sm1**2 / (exp(h_erg_s * nu_sm1 / kB_erg_Km1 / temperature_K) - 1)
 
 
 def nu_larmor(magnetic_field_gauss: np.ndarray) -> np.ndarray:
@@ -21,33 +22,32 @@ def nu_larmor(magnetic_field_gauss: np.ndarray) -> np.ndarray:
     return magnetic_field_gauss * mu0_erg_gaussm1 / h_erg_s
 
 
-def energy_cmm1_to_frequency_hz(energy_cmm1: FloatOrNDArrayT) -> FloatOrNDArrayT:
+def energy_cmm1_to_frequency_sm1(energy_cmm1: FloatOrNDArrayT) -> FloatOrNDArrayT:
     """
     Convert energy to frequency
     """
     return c_cm_sm1 * energy_cmm1
 
 
-def lambda_cm_to_frequency_hz(lambda_cm: FloatOrNDArrayT) -> FloatOrNDArrayT:
+def lambda_cm_to_frequency_sm1(lambda_cm: FloatOrNDArrayT) -> FloatOrNDArrayT:
     """
     Convert wavelength to frequency
     """
     return c_cm_sm1 / lambda_cm
 
 
-# Todo unify notation: hz vs Hz vs sm1
-def lambda_A_to_frequency_hz(lambda_A: FloatOrNDArrayT) -> FloatOrNDArrayT:
+def lambda_A_to_frequency_sm1(lambda_A: FloatOrNDArrayT) -> FloatOrNDArrayT:
     """
     Convert wavelength to frequency
     """
     return c_cm_sm1 * 1e8 / lambda_A
 
 
-def frequency_hz_to_lambda_A(frequency_hz: FloatOrNDArrayT) -> FloatOrNDArrayT:
+def frequency_sm1_to_lambda_A(frequency_sm1: FloatOrNDArrayT) -> FloatOrNDArrayT:
     """
     Convert frequency to wavelength
     """
-    return c_cm_sm1 / frequency_hz * 1e8
+    return c_cm_sm1 / frequency_sm1 * 1e8
 
 
 def energy_cmm1_to_erg(energy_cmm1: float) -> float:
@@ -61,17 +61,36 @@ def lambda_vacuum_to_air(lambda_vacuum_A: FloatOrNDArrayT) -> FloatOrNDArrayT:
     """
     Convert vacuum wavelength to air wavelength (Angstrom).
     Uses the Edlen (1966) formula, valid for ~2000-10000 A.
+    Reference: 10.1088/0026-1394/2/2/002
     """
     sigma2 = (1e4 / lambda_vacuum_A) ** 2
     n = 1 + (8342.13 + 2406030.0 / (130.0 - sigma2) + 15997.0 / (38.9 - sigma2)) * 1e-8
     return lambda_vacuum_A / n
 
 
-def lambda_air_to_vacuum(lambda_air_A: FloatOrNDArrayT) -> FloatOrNDArrayT:
+def lambda_air_to_vacuum(lambda_air_A: FloatOrNDArrayT, n_iter: int = 3) -> FloatOrNDArrayT:
     """
     Convert air wavelength to vacuum wavelength (Angstrom).
-    Uses the Edlen (1966) formula, valid for ~2000-10000 A.
+    Inverts Edlen (1966) vacuum-to-air relation by fixed-point iteration.
+    Reference: 10.1088/0026-1394/2/2/002
     """
-    sigma2 = (1e4 / lambda_air_A) ** 2
-    n = 1 + (8342.13 + 2406030.0 / (130.0 - sigma2) + 15997.0 / (38.9 - sigma2)) * 1e-8
-    return lambda_air_A * n
+    lambda_vac = lambda_air_A  # initial guess
+
+    for _ in range(n_iter):
+        sigma2 = (1e4 / lambda_vac) ** 2
+        n = 1 + (8342.13 + 2406030.0 / (130.0 - sigma2) + 15997.0 / (38.9 - sigma2)) * 1e-8
+        lambda_vac = lambda_air_A * n
+
+    return lambda_vac
+
+
+@log_function
+def get_frequencies_from_air_wavelength_range(
+    lower_wavelength_A: float, upper_wavelength_A: float, step_A: float
+) -> np.ndarray:
+    """
+    Build a frequency array (Hz) from a vacuum wavelength range (Angstrom).
+    """
+    lambda_A_air = np.arange(lower_wavelength_A, upper_wavelength_A, step_A)
+    lambda_A_vac = lambda_air_to_vacuum(lambda_A_air)
+    return lambda_A_to_frequency_sm1(lambda_A_vac)

--- a/solrat/atom_model/shared/utility/functions.py
+++ b/solrat/atom_model/shared/utility/functions.py
@@ -55,3 +55,23 @@ def energy_cmm1_to_erg(energy_cmm1: float) -> float:
     Convert energy units
     """
     return h_erg_s * c_cm_sm1 * energy_cmm1
+
+
+def lambda_vacuum_to_air(lambda_vacuum_A: FloatOrNDArrayT) -> FloatOrNDArrayT:
+    """
+    Convert vacuum wavelength to air wavelength (Angstrom).
+    Uses the Edlen (1966) formula, valid for ~2000-10000 A.
+    """
+    sigma2 = (1e4 / lambda_vacuum_A) ** 2
+    n = 1 + (8342.13 + 2406030.0 / (130.0 - sigma2) + 15997.0 / (38.9 - sigma2)) * 1e-8
+    return lambda_vacuum_A / n
+
+
+def lambda_air_to_vacuum(lambda_air_A: FloatOrNDArrayT) -> FloatOrNDArrayT:
+    """
+    Convert air wavelength to vacuum wavelength (Angstrom).
+    Uses the Edlen (1966) formula, valid for ~2000-10000 A.
+    """
+    sigma2 = (1e4 / lambda_air_A) ** 2
+    n = 1 + (8342.13 + 2406030.0 / (130.0 - sigma2) + 15997.0 / (38.9 - sigma2)) * 1e-8
+    return lambda_air_A * n

--- a/solrat/atom_model/shared/utility/log_setup.py
+++ b/solrat/atom_model/shared/utility/log_setup.py
@@ -1,0 +1,47 @@
+import logging
+
+import coloredlogs
+
+from solrat.engine.functions.decorators import VERBOSE
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    """
+    Initialize solrat logging.
+
+    Pass logging.INFO for normal output.
+    Pass logging.DEBUG to also see engine trace messages (VERBOSE level).
+    Third-party debug noise (scipy, pandas, etc.) is always suppressed.
+    """
+    logging.addLevelName(VERBOSE, "VERBOSE")
+
+    # Map DEBUG to VERBOSE so third-party DEBUG messages (level 10) stay hidden.
+    effective_level = VERBOSE if level == logging.DEBUG else level
+
+    coloredlogs.DEFAULT_FIELD_STYLES = dict(
+        asctime=dict(color="white"),
+        hostname=dict(color="magenta"),
+        levelname=dict(color="blue"),
+        name=dict(color="blue"),
+        programname=dict(color="cyan"),
+        username=dict(color="yellow"),
+        pathname=dict(color="white", faint=True),
+        lineno=dict(color="white", faint=True),
+    )
+
+    coloredlogs.DEFAULT_LEVEL_STYLES = dict(
+        spam=dict(color="green", faint=True),
+        debug=dict(color="white", faint=True),
+        verbose=dict(color="cyan", faint=True),
+        info=dict(color="green", bold=True),
+        notice=dict(color="magenta", bold=True),
+        warning=dict(color="yellow", bold=True),
+        success=dict(color="green", bold=True),
+        error=dict(color="red", bold=True),
+        critical=dict(color="red", bold=True),
+    )
+
+    coloredlogs.DEFAULT_LOG_LEVEL = effective_level
+    coloredlogs.DEFAULT_LOG_FORMAT = "%(pathname)s:%(lineno)d\n%(asctime)s %(levelname).4s %(message)s"
+    coloredlogs.DEFAULT_DATE_FORMAT = "%H:%M:%S"
+    coloredlogs.install()

--- a/solrat/atom_model/shared/utility/plot_stokes_profiles.py
+++ b/solrat/atom_model/shared/utility/plot_stokes_profiles.py
@@ -4,7 +4,12 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from solrat.atom_model.shared.object.stokes import Stokes
-from solrat.atom_model.shared.utility.functions import lambda_vacuum_to_air
+from solrat.atom_model.shared.utility.functions import (
+    frequency_sm1_to_lambda_A,
+    lambda_air_to_vacuum,
+    lambda_vacuum_to_air,
+)
+from solrat.engine.functions.decorators import log_method
 
 
 class StokesNorm(Enum):
@@ -16,52 +21,88 @@ class StokesNorm(Enum):
     MAX_IpV_ImV = auto()  # normalize I+V and I-V each by their own max (IpmV plotter only)
 
 
-def _x_axis(lambda_A, lambda_ref_A, vacuum_to_air):
-    """Compute x-axis values and label from wavelength array."""
-    if vacuum_to_air:
-        x = lambda_vacuum_to_air(lambda_A)
-        ref = lambda_vacuum_to_air(lambda_ref_A) if lambda_ref_A is not None else None
+def _compute_wavelength_axis(nu, reference_lambda_A_air, use_air_wavelengths):
+    lambda_A_vac = frequency_sm1_to_lambda_A(nu)
+    if use_air_wavelengths:
+        wavelength = lambda_vacuum_to_air(lambda_A_vac)
+        ref = reference_lambda_A_air
     else:
-        x = lambda_A
-        ref = lambda_ref_A
+        wavelength = lambda_A_vac
+        ref = lambda_air_to_vacuum(reference_lambda_A_air) if reference_lambda_A_air is not None else None
     if ref is not None:
-        return x - ref, r"$\Delta\lambda_\mathrm{air}$ ($\AA$)" if vacuum_to_air else r"$\Delta\lambda$ ($\AA$)"
-    return x, r"$\lambda_\mathrm{air}$ ($\AA$)" if vacuum_to_air else r"$\lambda$ ($\AA$)"
+        label = (
+            r"$\Delta\lambda_\mathrm{air}$ ($\AA$)" if use_air_wavelengths else r"$\Delta\lambda_\mathrm{vac}$ ($\AA$)"
+        )
+        return wavelength - ref, label
+    label = r"$\lambda_\mathrm{air}$ ($\AA$)" if use_air_wavelengths else r"$\lambda_\mathrm{vac}$ ($\AA$)"
+    return wavelength, label
 
 
-class StokesPlotter_IV:  # pragma: no cover
+class PlotterBase:  # pragma: no cover
+    Norm = StokesNorm
+
+    def __init__(
+        self, title, use_air_wavelengths, reference_lambda_A_air, n_axes, y_labels, figsize=(8, 8), x_label=None
+    ):
+        self.colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+        self.next_color_index = 0
+        self.vacuum_to_air = use_air_wavelengths
+        self.reference_lambda_A_air = reference_lambda_A_air
+        self.fig, self.axs = plt.subplots(n_axes, 1, sharex=True, constrained_layout=True, figsize=figsize, num=title)
+        self.fig.suptitle(title)
+        for ax, label in zip(self.axs, y_labels):
+            ax.set_ylabel(label)
+        self._wavelength_label = x_label
+
+    def _next_color(self, color):
+        if color == "auto":
+            color = self.colors[self.next_color_index % len(self.colors)]
+            self.next_color_index += 1
+        return color
+
+    def _wavelength_axis(self, nu):
+        wavelength, label = _compute_wavelength_axis(nu, self.reference_lambda_A_air, self.vacuum_to_air)
+        if self._wavelength_label is None:
+            self._wavelength_label = label
+        return wavelength
+
+    @log_method
+    def show(self):
+        for ax in self.axs:
+            ax.grid(True)
+            ax.legend(loc="upper left", bbox_to_anchor=(1.02, 1), fontsize="x-small")
+        self.axs[-1].set_xlabel(self._wavelength_label or r"$\lambda_\mathrm{vac}$ ($\AA$)")
+        plt.show()
+
+
+class StokesPlotter_IV(PlotterBase):  # pragma: no cover
     """
     Stokes plotter class for Stokes I and V profiles.
     """
 
-    def __init__(self, title="", vacuum_to_air=False):
-        self.colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
-        self.next_color_index = 0
-        self.vacuum_to_air = vacuum_to_air
-        self.fig, self.axs = plt.subplots(2, 1, sharex=True, constrained_layout=True, figsize=(8, 8), num=title)
-        self.fig.suptitle(title)
-        self.axs[0].set_ylabel(r"Stokes $I/I_{max}$")
-        self.axs[1].set_ylabel(r"Stokes $V/I_{max}$")
-        self._x_label = None
+    def __init__(self, title="", use_air_wavelengths=True, reference_lambda_A_air=None):
+        super().__init__(
+            title=title,
+            use_air_wavelengths=use_air_wavelengths,
+            reference_lambda_A_air=reference_lambda_A_air,
+            n_axes=2,
+            y_labels=[r"Stokes $I/I_{max}$", r"Stokes $V/I_{max}$"],
+        )
 
-    def add(self, lambda_A, stokes_I, stokes_V, lambda_ref_A=None, color=None, label="", linewidth=1.5):
-        if color == "auto":
-            color = self.colors[self.next_color_index % len(self.colors)]
-            self.next_color_index += 1
-
-        x, x_label = _x_axis(lambda_A, lambda_ref_A, self.vacuum_to_air)
-        self._x_label = x_label
-
+    @log_method
+    def add(self, nu, stokes_I, stokes_V, color=None, label="", linewidth=1.5):
+        color = self._next_color(color)
+        wavelength = self._wavelength_axis(nu)
         if stokes_I is not None:
-            self.axs[0].plot(x, stokes_I / np.max(stokes_I), label=label, color=color, linewidth=linewidth)
+            self.axs[0].plot(wavelength, stokes_I / np.max(stokes_I), label=label, color=color, linewidth=linewidth)
         if stokes_V is not None:
-            self.axs[1].plot(x, stokes_V / np.max(stokes_I), label=label, color=color, linewidth=linewidth)
+            self.axs[1].plot(wavelength, stokes_V / np.max(stokes_I), label=label, color=color, linewidth=linewidth)
 
+    @log_method
     def add_stokes(
         self,
-        lambda_A,
+        nu,
         stokes: Stokes,
-        lambda_ref_A=None,
         stokes_reference: Stokes = None,
         norm: StokesNorm = StokesNorm.NONE,
         color=None,
@@ -72,11 +113,13 @@ class StokesPlotter_IV:  # pragma: no cover
             scale = np.max(stokes.I)
         elif norm == StokesNorm.BY_REFERENCE:
             scale = stokes_reference.I
-        else:
+        elif norm == StokesNorm.NONE:
             scale = 1
+        else:
+            raise ValueError(f"Did not recognize normalization option {norm}")
+
         self.add(
-            lambda_A=lambda_A,
-            lambda_ref_A=lambda_ref_A,
+            nu=nu,
             stokes_I=stokes.I / scale,
             stokes_V=stokes.V / scale,
             color=color,
@@ -84,67 +127,45 @@ class StokesPlotter_IV:  # pragma: no cover
             linewidth=linewidth,
         )
 
-    def show(self):
-        self.axs[0].grid(True)
-        self.axs[1].grid(True)
-        self.axs[1].set_xlabel(self._x_label or r"$\lambda$ ($\AA$)")
 
-        for ax in self.axs:
-            ax.legend(
-                loc="upper left",
-                bbox_to_anchor=(1.02, 1),
-                fontsize="x-small",
-            )
-
-        plt.show()
-
-
-class StokesPlotter_IV_IpmV:  # pragma: no cover
+class StokesPlotter_IV_IpmV(PlotterBase):  # pragma: no cover
     r"""
     Stokes plotter class for Stokes :math:`I, V, I\pm V` profiles.
     """
 
-    def __init__(self, title="", vacuum_to_air=False):
-        self.colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
-        self.next_color_index = 0
-        self.vacuum_to_air = vacuum_to_air
-        self.fig, self.axs = plt.subplots(3, 1, sharex=True, constrained_layout=True, figsize=(8, 8), num=title)
-        self.fig.suptitle(title)
-        self.axs[0].set_ylabel(r"Stokes $I$")
-        self.axs[1].set_ylabel(r"Stokes $V$")
-        self.axs[2].set_ylabel(r"Stokes $(I\pm V)$")
-        self._x_label = None
+    def __init__(self, title="", use_air_wavelengths=False, reference_lambda_A_air=None):
+        super().__init__(
+            title=title,
+            use_air_wavelengths=use_air_wavelengths,
+            reference_lambda_A_air=reference_lambda_A_air,
+            n_axes=3,
+            y_labels=[r"Stokes $I$", r"Stokes $V$", r"Stokes $(I\pm V)$"],
+        )
 
-    def add(self, lambda_A, stokes_I, stokes_V, lambda_ref_A=None, color=None, label="", linewidth=1.5):
-        if color == "auto":
-            color = self.colors[self.next_color_index % len(self.colors)]
-            self.next_color_index += 1
+    @log_method
+    def add(self, nu, stokes_I, stokes_V, color=None, label="", linewidth=1.5):
+        color = self._next_color(color)
+        wavelength = self._wavelength_axis(nu)
+        self.axs[0].plot(wavelength, stokes_I, label=label, color=color, linewidth=linewidth)
+        self.axs[1].plot(wavelength, stokes_V, label=label, color=color, linewidth=linewidth)
+        self.axs[2].plot(wavelength, stokes_I + stokes_V, "-", label=label + " $I+V$", color=color, linewidth=linewidth)
+        self.axs[2].plot(
+            wavelength, stokes_I - stokes_V, "--", label=label + " $I-V$", color=color, linewidth=linewidth
+        )
 
-        x, x_label = _x_axis(lambda_A, lambda_ref_A, self.vacuum_to_air)
-        self._x_label = x_label
-
-        self.axs[0].plot(x, stokes_I, label=label, color=color, linewidth=linewidth)
-        self.axs[1].plot(x, stokes_V, label=label, color=color, linewidth=linewidth)
-        self.axs[2].plot(x, stokes_I + stokes_V, "-", label=label + " $I+V$", color=color, linewidth=linewidth)
-        self.axs[2].plot(x, stokes_I - stokes_V, "--", label=label + " $I-V$", color=color, linewidth=linewidth)
-
+    @log_method
     def add_stokes(
         self,
-        lambda_A,
+        nu,
         stokes: Stokes,
-        lambda_ref_A=None,
         stokes_reference: Stokes = None,
         norm: StokesNorm = StokesNorm.NONE,
         color=None,
         label="",
         linewidth=1.5,
     ):
-        if color == "auto":
-            color = self.colors[self.next_color_index % len(self.colors)]
-            self.next_color_index += 1
-
-        x, x_label = _x_axis(lambda_A, lambda_ref_A, self.vacuum_to_air)
-        self._x_label = x_label
+        color = self._next_color(color)
+        wavelength = self._wavelength_axis(nu)
 
         if norm == StokesNorm.NONE:
             I, V = stokes.I, stokes.V
@@ -156,9 +177,11 @@ class StokesPlotter_IV_IpmV:  # pragma: no cover
             I, V = stokes.I / scale, stokes.V / scale
         elif norm == StokesNorm.MAX_IpV_ImV:
             I, V = stokes.I, stokes.V
+        else:
+            raise ValueError(f"Did not recognize normalization option {norm}")
 
-        self.axs[0].plot(x, I, label=label, color=color, linewidth=linewidth)
-        self.axs[1].plot(x, V, label=label, color=color, linewidth=linewidth)
+        self.axs[0].plot(wavelength, I, label=label, color=color, linewidth=linewidth)
+        self.axs[1].plot(wavelength, V, label=label, color=color, linewidth=linewidth)
 
         if norm == StokesNorm.MAX_IpV_ImV:
             IpV = stokes.I + stokes.V
@@ -169,26 +192,11 @@ class StokesPlotter_IV_IpmV:  # pragma: no cover
             IpV = I + V
             ImV = I - V
 
-        self.axs[2].plot(x, IpV, "-", label=label + " $I+V$", color=color, linewidth=linewidth)
-        self.axs[2].plot(x, ImV, "--", label=label + " $I-V$", color=color, linewidth=linewidth)
-
-    def show(self):
-        self.axs[0].grid(True)
-        self.axs[1].grid(True)
-        self.axs[2].grid(True)
-        self.axs[2].set_xlabel(self._x_label or r"$\lambda$ ($\AA$)")
-
-        for ax in self.axs:
-            ax.legend(
-                loc="upper left",
-                bbox_to_anchor=(1.02, 1),
-                fontsize="x-small",
-            )
-
-        plt.show()
+        self.axs[2].plot(wavelength, IpV, "-", label=label + " $I+V$", color=color, linewidth=linewidth)
+        self.axs[2].plot(wavelength, ImV, "--", label=label + " $I-V$", color=color, linewidth=linewidth)
 
 
-class StokesPlotter:  # pragma: no cover
+class StokesPlotter(PlotterBase):  # pragma: no cover
     r"""
     Stokes plotter class for Stokes :math:`I, Q, U, V` profiles.
     """
@@ -196,59 +204,53 @@ class StokesPlotter:  # pragma: no cover
     def __init__(
         self,
         title="",
-        vacuum_to_air=False,
+        use_air_wavelengths=False,
+        reference_lambda_A_air=None,
         x_label=None,
         y_label_I=r"Stokes $I$",
         y_label_Q=r"Stokes $Q$",
         y_label_U=r"Stokes $U$",
         y_label_V=r"Stokes $V$",
     ):
-        self.colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
-        self.next_color_index = 0
-        self.vacuum_to_air = vacuum_to_air
-        self.fig, self.axs = plt.subplots(4, 1, sharex=True, constrained_layout=True, figsize=(8, 8), num=title)
-        self.fig.suptitle(title)
-        self.axs[0].set_ylabel(y_label_I)
-        self.axs[1].set_ylabel(y_label_Q)
-        self.axs[2].set_ylabel(y_label_U)
-        self.axs[3].set_ylabel(y_label_V)
-        self._x_label = x_label  # explicit override (e.g. for frequency axis)
+        super().__init__(
+            title=title,
+            use_air_wavelengths=use_air_wavelengths,
+            reference_lambda_A_air=reference_lambda_A_air,
+            n_axes=4,
+            y_labels=[y_label_I, y_label_Q, y_label_U, y_label_V],
+            x_label=x_label,
+        )
 
+    @log_method
     def add(
         self,
-        lambda_A,
+        nu,
         stokes_I,
         stokes_Q,
         stokes_U,
         stokes_V,
-        lambda_ref_A=None,
         color=None,
         label="",
         style="-",
         linewidth=1.5,
     ):
-        if color == "auto":
-            color = self.colors[self.next_color_index % len(self.colors)]
-            self.next_color_index += 1
-
-        x, x_label = _x_axis(lambda_A, lambda_ref_A, self.vacuum_to_air)
-        if self._x_label is None:
-            self._x_label = x_label
+        color = self._next_color(color)
+        wavelength = self._wavelength_axis(nu)
 
         if stokes_I is not None:
-            self.axs[0].plot(x, stokes_I, style, label=label, color=color, linewidth=linewidth)
+            self.axs[0].plot(wavelength, stokes_I, style, label=label, color=color, linewidth=linewidth)
         if stokes_Q is not None:
-            self.axs[1].plot(x, stokes_Q, style, label=label, color=color, linewidth=linewidth)
+            self.axs[1].plot(wavelength, stokes_Q, style, label=label, color=color, linewidth=linewidth)
         if stokes_U is not None:
-            self.axs[2].plot(x, stokes_U, style, label=label, color=color, linewidth=linewidth)
+            self.axs[2].plot(wavelength, stokes_U, style, label=label, color=color, linewidth=linewidth)
         if stokes_V is not None:
-            self.axs[3].plot(x, stokes_V, style, label=label, color=color, linewidth=linewidth)
+            self.axs[3].plot(wavelength, stokes_V, style, label=label, color=color, linewidth=linewidth)
 
+    @log_method
     def add_stokes(
         self,
-        lambda_A,
+        nu,
         stokes: Stokes,
-        lambda_ref_A=None,
         stokes_reference: Stokes = None,
         norm: StokesNorm = StokesNorm.NONE,
         color=None,
@@ -260,11 +262,12 @@ class StokesPlotter:  # pragma: no cover
             scale = np.max(stokes.I)
         elif norm == StokesNorm.BY_REFERENCE:
             scale = stokes_reference.I
-        else:
+        elif norm == StokesNorm.NONE:
             scale = 1
+        else:
+            raise ValueError(f"Did not recognize normalization option {norm}")
         self.add(
-            lambda_A=lambda_A,
-            lambda_ref_A=lambda_ref_A,
+            nu=nu,
             stokes_I=stokes.I / scale,
             stokes_Q=stokes.Q / scale,
             stokes_U=stokes.U / scale,
@@ -274,19 +277,3 @@ class StokesPlotter:  # pragma: no cover
             style=style,
             linewidth=linewidth,
         )
-
-    def show(self):
-        self.axs[0].grid(True)
-        self.axs[1].grid(True)
-        self.axs[2].grid(True)
-        self.axs[3].grid(True)
-        self.axs[3].set_xlabel(self._x_label or r"$\lambda$ ($\AA$)")
-
-        for ax in self.axs:
-            ax.legend(
-                loc="upper left",
-                bbox_to_anchor=(1.02, 1),
-                fontsize="x-small",
-            )
-
-        plt.show()

--- a/solrat/atom_model/shared/utility/plot_stokes_profiles.py
+++ b/solrat/atom_model/shared/utility/plot_stokes_profiles.py
@@ -1,148 +1,203 @@
+from enum import Enum, auto
+
 import numpy as np
 from matplotlib import pyplot as plt
 
 from solrat.atom_model.shared.object.stokes import Stokes
+from solrat.atom_model.shared.utility.functions import lambda_vacuum_to_air
+
+
+class StokesNorm(Enum):
+    """Normalization mode for Stokes profile plots."""
+
+    NONE = auto()  # raw values, no normalization
+    MAX_I = auto()  # divide all components by max(I)
+    BY_REFERENCE = auto()  # divide all components by reference Stokes I (continuum)
+    MAX_IpV_ImV = auto()  # normalize I+V and I-V each by their own max (IpmV plotter only)
+
+
+def _x_axis(lambda_A, lambda_ref_A, vacuum_to_air):
+    """Compute x-axis values and label from wavelength array."""
+    if vacuum_to_air:
+        x = lambda_vacuum_to_air(lambda_A)
+        ref = lambda_vacuum_to_air(lambda_ref_A) if lambda_ref_A is not None else None
+    else:
+        x = lambda_A
+        ref = lambda_ref_A
+    if ref is not None:
+        return x - ref, r"$\Delta\lambda_\mathrm{air}$ ($\AA$)" if vacuum_to_air else r"$\Delta\lambda$ ($\AA$)"
+    return x, r"$\lambda_\mathrm{air}$ ($\AA$)" if vacuum_to_air else r"$\lambda$ ($\AA$)"
 
 
 class StokesPlotter_IV:  # pragma: no cover
     """
     Stokes plotter class for Stokes I and V profiles.
-    Todo: unify interface.
     """
 
-    def __init__(self, title=""):
+    def __init__(self, title="", vacuum_to_air=False):
         self.colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
         self.next_color_index = 0
+        self.vacuum_to_air = vacuum_to_air
         self.fig, self.axs = plt.subplots(2, 1, sharex=True, constrained_layout=True, figsize=(8, 8), num=title)
+        self.fig.suptitle(title)
         self.axs[0].set_ylabel(r"Stokes $I/I_{max}$")
         self.axs[1].set_ylabel(r"Stokes $V/I_{max}$")
+        self._x_label = None
 
-    def add(self, lambda_A, reference_lambda_A, stokes_I, stokes_V, color=None, label="", linewidth=1):
+    def add(self, lambda_A, stokes_I, stokes_V, lambda_ref_A=None, color=None, label="", linewidth=1.5):
         if color == "auto":
             color = self.colors[self.next_color_index % len(self.colors)]
             self.next_color_index += 1
 
+        x, x_label = _x_axis(lambda_A, lambda_ref_A, self.vacuum_to_air)
+        self._x_label = x_label
+
         if stokes_I is not None:
-            self.axs[0].plot(
-                lambda_A - reference_lambda_A, stokes_I / max(stokes_I), label=label, color=color, linewidth=linewidth
-            )
+            self.axs[0].plot(x, stokes_I / np.max(stokes_I), label=label, color=color, linewidth=linewidth)
         if stokes_V is not None:
-            self.axs[1].plot(
-                lambda_A - reference_lambda_A, stokes_V / max(stokes_I), label=label, color=color, linewidth=linewidth
-            )
+            self.axs[1].plot(x, stokes_V / np.max(stokes_I), label=label, color=color, linewidth=linewidth)
+
+    def add_stokes(
+        self,
+        lambda_A,
+        stokes: Stokes,
+        lambda_ref_A=None,
+        stokes_reference: Stokes = None,
+        norm: StokesNorm = StokesNorm.NONE,
+        color=None,
+        label="",
+        linewidth=1.5,
+    ):
+        if norm == StokesNorm.MAX_I:
+            scale = np.max(stokes.I)
+        elif norm == StokesNorm.BY_REFERENCE:
+            scale = stokes_reference.I
+        else:
+            scale = 1
+        self.add(
+            lambda_A=lambda_A,
+            lambda_ref_A=lambda_ref_A,
+            stokes_I=stokes.I / scale,
+            stokes_V=stokes.V / scale,
+            color=color,
+            label=label,
+            linewidth=linewidth,
+        )
 
     def show(self):
         self.axs[0].grid(True)
         self.axs[1].grid(True)
-        self.axs[1].set_xlabel(r"$\Delta\lambda$ ($\AA$)")
+        self.axs[1].set_xlabel(self._x_label or r"$\lambda$ ($\AA$)")
 
-        self.axs[0].legend(
-            loc="upper left",
-            bbox_to_anchor=(1.02, 1),  # Centered above the axes
-            fontsize="x-small",
-        )
+        for ax in self.axs:
+            ax.legend(
+                loc="upper left",
+                bbox_to_anchor=(1.02, 1),
+                fontsize="x-small",
+            )
 
-        self.axs[1].legend(
-            loc="upper left",
-            bbox_to_anchor=(1.02, 1),  # Centered above the axes
-            fontsize="x-small",
-        )
         plt.show()
 
 
 class StokesPlotter_IV_IpmV:  # pragma: no cover
     r"""
     Stokes plotter class for Stokes :math:`I, V, I\pm V` profiles.
-    Todo: unify interface.
     """
 
-    def __init__(self, title=""):
+    def __init__(self, title="", vacuum_to_air=False):
         self.colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
         self.next_color_index = 0
+        self.vacuum_to_air = vacuum_to_air
         self.fig, self.axs = plt.subplots(3, 1, sharex=True, constrained_layout=True, figsize=(8, 8), num=title)
         self.fig.suptitle(title)
         self.axs[0].set_ylabel(r"Stokes $I$")
         self.axs[1].set_ylabel(r"Stokes $V$")
         self.axs[2].set_ylabel(r"Stokes $(I\pm V)$")
+        self._x_label = None
 
-    def add(self, lambda_A, reference_lambda_A, stokes_I, stokes_V, color=None, label=""):
+    def add(self, lambda_A, stokes_I, stokes_V, lambda_ref_A=None, color=None, label="", linewidth=1.5):
         if color == "auto":
             color = self.colors[self.next_color_index % len(self.colors)]
             self.next_color_index += 1
 
-        self.axs[0].plot(lambda_A - reference_lambda_A, stokes_I, label=label, color=color, linewidth=1)
-        self.axs[1].plot(lambda_A - reference_lambda_A, stokes_V, label=label, color=color, linewidth=1)
-        self.axs[2].plot(
-            lambda_A - reference_lambda_A,
-            (stokes_I + stokes_V),
-            "-",
-            label=label + " $I+V$",
-            color=color,
-            linewidth=1,
-        )
-        self.axs[2].plot(
-            lambda_A - reference_lambda_A,
-            (stokes_I - stokes_V),
-            "--",
-            label=label + " $I-V$",
-            color=color,
-            linewidth=1,
-        )
+        x, x_label = _x_axis(lambda_A, lambda_ref_A, self.vacuum_to_air)
+        self._x_label = x_label
+
+        self.axs[0].plot(x, stokes_I, label=label, color=color, linewidth=linewidth)
+        self.axs[1].plot(x, stokes_V, label=label, color=color, linewidth=linewidth)
+        self.axs[2].plot(x, stokes_I + stokes_V, "-", label=label + " $I+V$", color=color, linewidth=linewidth)
+        self.axs[2].plot(x, stokes_I - stokes_V, "--", label=label + " $I-V$", color=color, linewidth=linewidth)
 
     def add_stokes(
         self,
         lambda_A,
-        reference_lambda_A,
         stokes: Stokes,
+        lambda_ref_A=None,
         stokes_reference: Stokes = None,
+        norm: StokesNorm = StokesNorm.NONE,
         color=None,
         label="",
+        linewidth=1.5,
     ):
-        scale = 1 if stokes_reference is None else stokes_reference.I
-        self.add(
-            lambda_A=lambda_A,
-            reference_lambda_A=reference_lambda_A,
-            stokes_I=stokes.I / scale,
-            stokes_V=stokes.V / scale,
-            color=color,
-            label=label,
-        )
+        if color == "auto":
+            color = self.colors[self.next_color_index % len(self.colors)]
+            self.next_color_index += 1
+
+        x, x_label = _x_axis(lambda_A, lambda_ref_A, self.vacuum_to_air)
+        self._x_label = x_label
+
+        if norm == StokesNorm.NONE:
+            I, V = stokes.I, stokes.V
+        elif norm == StokesNorm.MAX_I:
+            scale = np.max(stokes.I)
+            I, V = stokes.I / scale, stokes.V / scale
+        elif norm == StokesNorm.BY_REFERENCE:
+            scale = stokes_reference.I
+            I, V = stokes.I / scale, stokes.V / scale
+        elif norm == StokesNorm.MAX_IpV_ImV:
+            I, V = stokes.I, stokes.V
+
+        self.axs[0].plot(x, I, label=label, color=color, linewidth=linewidth)
+        self.axs[1].plot(x, V, label=label, color=color, linewidth=linewidth)
+
+        if norm == StokesNorm.MAX_IpV_ImV:
+            IpV = stokes.I + stokes.V
+            ImV = stokes.I - stokes.V
+            IpV = IpV / np.max(np.abs(IpV))
+            ImV = ImV / np.max(np.abs(ImV))
+        else:
+            IpV = I + V
+            ImV = I - V
+
+        self.axs[2].plot(x, IpV, "-", label=label + " $I+V$", color=color, linewidth=linewidth)
+        self.axs[2].plot(x, ImV, "--", label=label + " $I-V$", color=color, linewidth=linewidth)
 
     def show(self):
         self.axs[0].grid(True)
         self.axs[1].grid(True)
         self.axs[2].grid(True)
-        self.axs[2].set_xlabel(r"$\Delta\lambda$ ($\AA$)")
+        self.axs[2].set_xlabel(self._x_label or r"$\lambda$ ($\AA$)")
 
-        self.axs[0].legend(
-            loc="upper left",
-            bbox_to_anchor=(1.02, 1),  # Centered above the axes
-            fontsize="x-small",
-        )
+        for ax in self.axs:
+            ax.legend(
+                loc="upper left",
+                bbox_to_anchor=(1.02, 1),
+                fontsize="x-small",
+            )
 
-        self.axs[1].legend(
-            loc="upper left",
-            bbox_to_anchor=(1.02, 1),  # Centered above the axes
-            fontsize="x-small",
-        )
-        self.axs[2].legend(
-            loc="upper left",
-            bbox_to_anchor=(1.02, 1),  # Centered above the axes
-            fontsize="x-small",
-        )
         plt.show()
 
 
 class StokesPlotter:  # pragma: no cover
     r"""
     Stokes plotter class for Stokes :math:`I, Q, U, V` profiles.
-    Todo: unify interface.
     """
 
     def __init__(
         self,
         title="",
-        x_label=r"$\Delta\lambda$ ($\AA$)",
+        vacuum_to_air=False,
+        x_label=None,
         y_label_I=r"Stokes $I$",
         y_label_Q=r"Stokes $Q$",
         y_label_U=r"Stokes $U$",
@@ -150,22 +205,23 @@ class StokesPlotter:  # pragma: no cover
     ):
         self.colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
         self.next_color_index = 0
+        self.vacuum_to_air = vacuum_to_air
         self.fig, self.axs = plt.subplots(4, 1, sharex=True, constrained_layout=True, figsize=(8, 8), num=title)
         self.fig.suptitle(title)
         self.axs[0].set_ylabel(y_label_I)
         self.axs[1].set_ylabel(y_label_Q)
         self.axs[2].set_ylabel(y_label_U)
         self.axs[3].set_ylabel(y_label_V)
-        self.x_label = x_label
+        self._x_label = x_label  # explicit override (e.g. for frequency axis)
 
     def add(
         self,
         lambda_A,
-        reference_lambda_A,
         stokes_I,
         stokes_Q,
         stokes_U,
         stokes_V,
+        lambda_ref_A=None,
         color=None,
         label="",
         style="-",
@@ -175,44 +231,40 @@ class StokesPlotter:  # pragma: no cover
             color = self.colors[self.next_color_index % len(self.colors)]
             self.next_color_index += 1
 
+        x, x_label = _x_axis(lambda_A, lambda_ref_A, self.vacuum_to_air)
+        if self._x_label is None:
+            self._x_label = x_label
+
         if stokes_I is not None:
-            self.axs[0].plot(
-                lambda_A - reference_lambda_A, stokes_I, style, label=label, color=color, linewidth=linewidth
-            )
-
+            self.axs[0].plot(x, stokes_I, style, label=label, color=color, linewidth=linewidth)
         if stokes_Q is not None:
-            self.axs[1].plot(
-                lambda_A - reference_lambda_A, stokes_Q, style, label=label, color=color, linewidth=linewidth
-            )
-
+            self.axs[1].plot(x, stokes_Q, style, label=label, color=color, linewidth=linewidth)
         if stokes_U is not None:
-            self.axs[2].plot(
-                lambda_A - reference_lambda_A, stokes_U, style, label=label, color=color, linewidth=linewidth
-            )
-
+            self.axs[2].plot(x, stokes_U, style, label=label, color=color, linewidth=linewidth)
         if stokes_V is not None:
-            self.axs[3].plot(
-                lambda_A - reference_lambda_A, stokes_V, style, label=label, color=color, linewidth=linewidth
-            )
+            self.axs[3].plot(x, stokes_V, style, label=label, color=color, linewidth=linewidth)
 
     def add_stokes(
         self,
         lambda_A,
-        reference_lambda_A,
         stokes: Stokes,
+        lambda_ref_A=None,
         stokes_reference: Stokes = None,
+        norm: StokesNorm = StokesNorm.NONE,
         color=None,
         label="",
         style="-",
         linewidth=1.5,
-        normalize=False,
     ):
-        scale = 1 if stokes_reference is None else stokes_reference.I
-        if normalize:
+        if norm == StokesNorm.MAX_I:
             scale = np.max(stokes.I)
+        elif norm == StokesNorm.BY_REFERENCE:
+            scale = stokes_reference.I
+        else:
+            scale = 1
         self.add(
             lambda_A=lambda_A,
-            reference_lambda_A=reference_lambda_A,
+            lambda_ref_A=lambda_ref_A,
             stokes_I=stokes.I / scale,
             stokes_Q=stokes.Q / scale,
             stokes_U=stokes.U / scale,
@@ -228,12 +280,13 @@ class StokesPlotter:  # pragma: no cover
         self.axs[1].grid(True)
         self.axs[2].grid(True)
         self.axs[3].grid(True)
-        self.axs[3].set_xlabel(self.x_label)
+        self.axs[3].set_xlabel(self._x_label or r"$\lambda$ ($\AA$)")
 
-        self.axs[0].legend(
-            loc="upper left",
-            bbox_to_anchor=(1.02, 1),  # Centered above the axes
-            fontsize="x-small",
-        )
+        for ax in self.axs:
+            ax.legend(
+                loc="upper left",
+                bbox_to_anchor=(1.02, 1),
+                fontsize="x-small",
+            )
 
         plt.show()

--- a/solrat/atom_model/shared/utility/wigner_3j_6j_9j.py
+++ b/solrat/atom_model/shared/utility/wigner_3j_6j_9j.py
@@ -194,17 +194,17 @@ def _w9j_doubled_argument(
 _w3j_doubled_argument_vec = np.vectorize(_w3j_doubled_argument)
 _w6j_doubled_argument_vec = np.vectorize(_w6j_doubled_argument)
 
+# Todo investigate caching vs vectorization performance.
 
-# @lru_cache(maxsize=None)
+
 def wigner_3j(j1, j2, j3, m1, m2, m3):
     return _w3j_doubled_argument_vec(j1 * 2, j2 * 2, j3 * 2, m1 * 2, m2 * 2, m3 * 2)
 
 
-# @lru_cache(maxsize=None)
 def wigner_6j(j1, j2, j3, l1, l2, l3):
     return _w6j_doubled_argument_vec(j1 * 2, j2 * 2, j3 * 2, l1 * 2, l2 * 2, l3 * 2)
 
 
-@lru_cache(maxsize=None)  # Todo investigate caching vs vectorization performance
+@lru_cache(maxsize=None)
 def wigner_9j(j1, j2, j3, j4, j5, j6, j7, j8, j9):
     return _w9j_doubled_argument(j1 * 2, j2 * 2, j3 * 2, j4 * 2, j5 * 2, j6 * 2, j7 * 2, j8 * 2, j9 * 2)

--- a/solrat/engine/functions/decorators.py
+++ b/solrat/engine/functions/decorators.py
@@ -4,7 +4,10 @@ import logging
 import threading
 import time
 
-LOGGING_LEVEL = logging.INFO
+VERBOSE = 15
+logging.addLevelName(VERBOSE, "VERBOSE")
+
+LOGGING_LEVEL = VERBOSE
 _state = threading.local()
 
 

--- a/solrat/engine/functions/special.py
+++ b/solrat/engine/functions/special.py
@@ -1,18 +1,19 @@
-import logging
 from typing import TypeVar
 
 import numpy as np
+
+from solrat.engine.functions.decorators import log_function
 
 FloatOrNDArrayT = TypeVar("FloatOrNDArrayT", float, np.ndarray)
 IntOrFloatT = TypeVar("IntOrFloatT", int, float)
 NumericT = TypeVar("NumericT", int, float, complex, np.ndarray)
 
 
+@log_function
 def pseudo_hash(stokesI, stokesQ, stokesU, stokesV):
     """
     Construct a pseudo-unique, likely non-trivial real float hash from 4 complex arrays
     """
-    logging.info(stokesQ.shape)
     if stokesI.shape[0] % 2 == 1:
         stokesI = stokesI[:-1] + stokesI[-1]
         stokesQ = stokesQ[:-1] + stokesQ[-1]

--- a/solrat/engine/generators/merge_frame.py
+++ b/solrat/engine/generators/merge_frame.py
@@ -5,6 +5,7 @@ from typing import Callable, Dict, Generic, List, TypeVar, Union
 import numpy as np
 import pandas as pd
 
+from solrat.engine.functions.decorators import VERBOSE, log_method
 from solrat.engine.generators.merge_loopers import DummyOrAlreadyMerged, Looper
 
 
@@ -74,7 +75,7 @@ class FrameFactor:
             self.dependencies: List[str] = [p.name for p in inspect.signature(factor).parameters.values()]
         self.merged: bool = merged
         self.elementwise: bool = elementwise
-        logging.info(f"Created: {self}")
+        logging.log(VERBOSE, f"Created: {self}")
 
     def __repr__(self):
         return (
@@ -82,6 +83,7 @@ class FrameFactor:
             f"Elementwise: {self.elementwise}"
         )
 
+    @log_method
     def copy(self):
         return FrameFactor(
             name=self.name,
@@ -120,18 +122,19 @@ class Frame(Generic[SumLimitsT]):
             sub_frame_filled = looper.fill_frame(sub_frame)
             assert not sub_frame_filled[looper_name].isna().any()
             self.frame = merge(self.frame, sub_frame_filled)
-            logging.info(f"Merged {looper_name}, frame shape = {self.frame.shape}")
+            logging.log(VERBOSE, f"Merged {looper_name}, frame shape = {self.frame.shape}")
 
         self.factors: Dict[str, FrameFactor] = {}
         self._n_factors = 0  # for naming only
-        logging.info(f"Frame shape after initialization: {self.frame.shape}")
+        logging.log(VERBOSE, f"Frame shape after initialization: {self.frame.shape}")
 
+    @log_method
     def copy(self):
         new_frame = Frame()
         new_frame.frame = self.frame.copy()
         new_frame.factors = {k: factor.copy() for k, factor in self.factors.items()}
         new_frame._n_factors = self._n_factors
-        logging.info(f"new frame: {new_frame}")
+        logging.log(VERBOSE, f"new frame: {new_frame}")
         return new_frame
 
     def __repr__(self):  # pragma: no cover
@@ -150,6 +153,7 @@ class Frame(Generic[SumLimitsT]):
 
         return result
 
+    @log_method
     def construct_sub_frame(self, columns: List[str]) -> pd.DataFrame:
         """
         This is used to reduce the evaluations of loopers/factors to minimum:
@@ -159,6 +163,7 @@ class Frame(Generic[SumLimitsT]):
             return pd.DataFrame(index=[0], columns=[])
         return self.frame[columns].drop_duplicates().reset_index(drop=True)
 
+    @log_method
     def register_multiplication(self, *args: Callable, elementwise: bool = False, **kwargs):
         """
         This just registers the factors. They will be evaluated/merged later on demand.
@@ -177,12 +182,13 @@ class Frame(Generic[SumLimitsT]):
     def get_dependent_factors(self, column: str) -> List[str]:
         return [name for name, factor in self.factors.items() if column in factor.dependencies]
 
+    @log_method
     def merge_factor(self, factor_name: str):
         """
         Construct factor frame, evaluate, and merge it to the main frame
         """
         factor = self.factors[factor_name]
-        logging.info(f"..Merging factor: {factor}")
+        logging.log(VERBOSE, f"Merging factor: {factor}")
 
         factor_frame = self.construct_sub_frame(factor.dependencies)
         # Reshape the dependencies so that they support vector evals.
@@ -201,6 +207,7 @@ class Frame(Generic[SumLimitsT]):
         self.frame = merge(self.frame, factor_frame)
         factor.merged = True
 
+    @log_method
     def combine_all_merged_factors(self):
         """
         Multiply all merged factors so that the frame has a single combined merged factor.
@@ -223,6 +230,7 @@ class Frame(Generic[SumLimitsT]):
 
         return new_factor_name
 
+    @log_method
     def remove_dependency(self, column: str):
         for factor in self.factors.values():
             if column in factor.dependencies:
@@ -233,6 +241,7 @@ class Frame(Generic[SumLimitsT]):
         """Get looper columns other than the specified one"""
         return [col for col in self.frame.columns if col != exclude and col not in self.factors]
 
+    @log_method
     def reduce_single_index(self, column: Union[str, Looper]):
         """
         Reduction is Looper-wise (this way it clearly follows the logic of 'summation' operation)
@@ -240,43 +249,44 @@ class Frame(Generic[SumLimitsT]):
         if isinstance(column, Looper):
             column = column.get_name()
 
-        logging.info("====")
-        logging.info(f"Reducing column {column}:")
+        logging.log(VERBOSE, "====")
+        logging.log(VERBOSE, f"Reducing column {column}:")
         dependent_factors = self.get_dependent_factors(column)
-        logging.info(f"Dependent factors: {dependent_factors}")
-        logging.info(f"Dependent factors details: {[self.factors[df] for df in dependent_factors]}")
+        logging.log(VERBOSE, f"Dependent factors: {dependent_factors}")
+        logging.log(VERBOSE, f"Dependent factors details: {[self.factors[df] for df in dependent_factors]}")
 
         if len(dependent_factors) == 0:
-            logging.info(f"No dependent factors for column {column}, dropping it directly.")
+            logging.log(VERBOSE, f"No dependent factors for column {column}, dropping it directly.")
             self.remove_dependency(column)
             self.frame = self.frame.drop(columns=column)
             return self.frame
 
         for factor_name in dependent_factors:
-            logging.info(f"  Ensuring factor {factor_name} is merged for reduction.")
+            logging.log(VERBOSE, f"Ensuring factor {factor_name} is merged for reduction.")
             if not self.factors[factor_name].merged:
-                logging.info(f"    Merging factor {factor_name} now.")
+                logging.log(VERBOSE, f"    Merging factor {factor_name} now.")
                 self.merge_factor(factor_name)
 
         factor_name = self.combine_all_merged_factors()
-        logging.info(f"  Combined dependent factors into {factor_name} for reduction.")
+        logging.log(VERBOSE, f"Combined dependent factors into {factor_name} for reduction.")
         self.remove_dependency(column)
 
         group_columns = self.get_other_frame_columns(column)
-        logging.info(f"  Grouping by columns: {group_columns} to reduce {column}.")
+        logging.log(VERBOSE, f"  Grouping by columns: {group_columns} to reduce {column}.")
 
         if len(group_columns) == 0:
-            logging.info("  Reduced the last looper!")
+            logging.log(VERBOSE, "  Reduced the last looper!")
             assert len(self.factors) == 1, f"Reduced all loopers, but some factors remain: {self.factors}"
             # self.frame = self.frame.drop(columns=column)
-            # logging.info(f"  No grouping columns left, returning sum of {factor_name}.")
-            logging.info("Calculating the sum over the last looper and returning the result")
+            # logging.log(VERBOSE, f"  No grouping columns left, returning sum of {factor_name}.")
+            logging.log(VERBOSE, "Calculating the sum over the last looper and returning the result")
             return self.frame[factor_name].sum()
 
         self.frame = self.frame.groupby(group_columns)[factor_name].sum().reset_index()
-        logging.info(f"  Reduced frame shape: {self.frame.shape}")
+        logging.log(VERBOSE, f"  Reduced frame shape: {self.frame.shape}")
         return None
 
+    @log_method
     def _reduce(self, columns) -> Union[np.ndarray, float, complex, None]:
         result = None
         for col in columns:
@@ -285,6 +295,7 @@ class Frame(Generic[SumLimitsT]):
             result = self.reduce_single_index(col)
         return result
 
+    @log_method
     def reduce(self, *args: Union[Looper, str]) -> Union[np.ndarray, float, complex, None]:
         r"""usage:
         frame.reduce() to reduce all,
@@ -321,6 +332,7 @@ class Frame(Generic[SumLimitsT]):
         frame_columns = columns_before + ellipsis_columns + columns_after
         return self._reduce(frame_columns)
 
+    @log_method
     def debug_reduce_legacy(self):  # pragma: no cover
         for factor_name in list(self.factors.keys()):
             self.merge_factor(factor_name)

--- a/solrat/engine/generators/merge_frame.py
+++ b/solrat/engine/generators/merge_frame.py
@@ -134,7 +134,6 @@ class Frame(Generic[SumLimitsT]):
         new_frame.frame = self.frame.copy()
         new_frame.factors = {k: factor.copy() for k, factor in self.factors.items()}
         new_frame._n_factors = self._n_factors
-        logging.log(VERBOSE, f"new frame: {new_frame}")
         return new_frame
 
     def __repr__(self):  # pragma: no cover
@@ -153,7 +152,6 @@ class Frame(Generic[SumLimitsT]):
 
         return result
 
-    @log_method
     def construct_sub_frame(self, columns: List[str]) -> pd.DataFrame:
         """
         This is used to reduce the evaluations of loopers/factors to minimum:

--- a/solrat/engine/generators/merge_loopers.py
+++ b/solrat/engine/generators/merge_loopers.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from abc import abstractmethod
 from functools import reduce
 from typing import Set, Union
@@ -6,13 +7,24 @@ from typing import Set, Union
 import numpy as np
 import pandas as pd
 
-MAX_LOOPER_ID = 0
+from solrat.engine.functions.decorators import log_function
+
+_max_looper_id = threading.local()
 
 
+def _get_max_looper_id() -> int:
+    return getattr(_max_looper_id, "level", 0)
+
+
+def _set_max_looper_id(value: int) -> None:
+    _max_looper_id.level = value
+
+
+@log_function
 def get_unique_name() -> str:
-    global MAX_LOOPER_ID
-    name = f"__looper_unique_{MAX_LOOPER_ID}__"
-    MAX_LOOPER_ID += 1
+    new_id = _get_max_looper_id()
+    name = f"__looper_unique_{new_id}__"
+    _set_max_looper_id(new_id + 1)
     return name
 
 
@@ -317,8 +329,8 @@ class Intersection(Looper):
         if frame[name].isna().any():
             msg = (
                 f"NaN values found in intersection looper {name}. "
-                f"Check previous loopers for possible optimization (triangular conditions etc). "
-                f"If not applicable - double check the logic."
+                f"This typically means that not all triangular conditions were accounted for in SumLimits. "
+                f"This warning is expected for current implementation of LL04 multi-term atom for Q/Qu/Ql loopers."
             )
             logging.warning(msg)
         frame = frame.dropna(subset=[name])

--- a/solrat/engine/generators/merge_loopers.py
+++ b/solrat/engine/generators/merge_loopers.py
@@ -7,7 +7,6 @@ from typing import Set, Union
 import numpy as np
 import pandas as pd
 
-from solrat.engine.functions.decorators import log_function
 
 _max_looper_id = threading.local()
 
@@ -20,7 +19,6 @@ def _set_max_looper_id(value: int) -> None:
     _max_looper_id.level = value
 
 
-@log_function
 def get_unique_name() -> str:
     new_id = _get_max_looper_id()
     name = f"__looper_unique_{new_id}__"

--- a/solrat/engine/generators/merge_loopers.py
+++ b/solrat/engine/generators/merge_loopers.py
@@ -7,7 +7,6 @@ from typing import Set, Union
 import numpy as np
 import pandas as pd
 
-
 _max_looper_id = threading.local()
 
 


### PR DESCRIPTION
Clean up RTE interface:
- compute all Stokes parameters in one Frame
- access Einstein coefficients inside TransitionRegistry
- add caching for Paschen-Back eigenvalue problem solving and custom PaschenBack container class
- add caching/precomputing of eta_a and eta_s frames
- remove Einstein coefficients from loopers, merge them together with other factors instead
- remove Paschen-Back explicit pre-computation

General clean-up:
- automatically adjust for air index when plotting Stokes profiles
- unify and refactor plotters
- add clean normalization to plotters
- improve argument names
- unify hz vs sm1
- use VERBOSE logging level for debugging
- make loopers thread-safe
- use custom logging init instead of yatools

New tests/demos:
- add Hanle effect demo
- add demo for LTE magnetic sensitivity of Mn I 5432 
- add demo for quick-start of SolRaT
- add test to check that precomputing of SEE works as intended
- add test to check the disable_r_s option of current vs legacy SEE implementation
- add test to compare current vs legacy implementation of SEE for non-zero magnetic field
- add test for sanity checks in SEE of some real atoms
